### PR TITLE
Fix location of java after openjdk moved in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN apt-get update
 RUN apt-get -yq install curl
 RUN apt-get -yq clean
 
-CMD exec /usr/bin/java $JAVA_OPTS -jar /opt/census-rm-case-api.jar
+CMD exec /usr/local/openjdk-11/bin/java $JAVA_OPTS -jar /opt/census-rm-case-api.jar

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This service provides a read-only API for case details.
 
 # How to run
 The Case Api service requires a Postgres instance to be running which contains the new casev2 schema.
-Postgres can be started using either census-rm-docker-dev or "docker-compose up -d postgres-database"
+Postgres can be started using either census-rm-docker-dev or "docker-compose up -d postgres-database".
 
 # How to test
 make test


### PR DESCRIPTION
# Motivation and Context
The docker image `openjdk:11-slim` has changed the location of the `java` binary.

# What has changed
Changed the `java` path to the correct one.

# How to test?
Build the image. Container should start.

# Links
Trello: https://trello.com/c/7ivpCfY6
Reasons why stuff got broken: https://github.com/docker-library/openjdk/issues/320#issuecomment-494417274

# Screenshots (if appropriate):