### PR TITLE
add address type to find by qid return class

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -21,7 +21,7 @@ import uk.gov.ons.census.caseapisvc.exception.CaseIdNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.CaseReferenceNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.UPRNNotFoundException;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
-import uk.gov.ons.census.caseapisvc.model.dto.CaseIdDto;
+import uk.gov.ons.census.caseapisvc.model.dto.CaseIdAddressTypeDto;
 import uk.gov.ons.census.caseapisvc.model.dto.EventDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
@@ -69,13 +69,14 @@ public final class CaseEndpoint {
   }
 
   @GetMapping(value = "/qid/{qid}")
-  public CaseIdDto findCaseByQid(@PathVariable("qid") String qid) {
+  public CaseIdAddressTypeDto findCaseByQid(@PathVariable("qid") String qid) {
     log.debug("Entering findByQid");
     Case caze = caseService.findCaseByQid(qid);
-    CaseIdDto caseIdDto = new CaseIdDto();
-    caseIdDto.setCaseId(caze.getCaseId().toString());
+    CaseIdAddressTypeDto caseIdAddressTypeDto = new CaseIdAddressTypeDto();
+    caseIdAddressTypeDto.setCaseId(caze.getCaseId().toString());
+    caseIdAddressTypeDto.setAddressType(caze.getAddressType());
 
-    return caseIdDto;
+    return caseIdAddressTypeDto;
   }
 
   @GetMapping(value = "/ref/{reference}")

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseIdAddressTypeDto.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseIdAddressTypeDto.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.caseapisvc.model.dto;
 import lombok.Data;
 
 @Data
-public class CaseIdDto {
+public class CaseIdAddressTypeDto {
   private String caseId;
+  private String addressType;
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -25,7 +25,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
-import uk.gov.ons.census.caseapisvc.model.dto.CaseIdDto;
+import uk.gov.ons.census.caseapisvc.model.dto.CaseIdAddressTypeDto;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.EventType;
@@ -50,6 +50,7 @@ public class CaseEndpointIT {
 
   private static final String TEST_REFERENCE_DOES_NOT_EXIST = "99999999";
   public static final String TEST_QID = "test_qid";
+  public static final String ADDRESS_TYPE_TEST = "addressTypeTest";
 
   @LocalServerPort private int port;
 
@@ -304,8 +305,10 @@ public class CaseEndpointIT {
             .header("accept", "application/json")
             .asJson();
 
-    CaseIdDto caseIdDto = DataUtils.extractCaseIdDtoFromResponse(jsonResponse);
-    assertThat(caseIdDto.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    CaseIdAddressTypeDto caseIdAddressTypeDto =
+        DataUtils.extractCaseIdDtoFromResponse(jsonResponse);
+    assertThat(caseIdAddressTypeDto.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(caseIdAddressTypeDto.getAddressType()).isEqualTo(ADDRESS_TYPE_TEST);
   }
 
   private Case createOneTestCaseWithEvent() {
@@ -361,6 +364,7 @@ public class CaseEndpointIT {
     caze.setEvents(null);
     caze.setUprn(TEST_UPRN_EXISTS);
     caze.setReceiptReceived(false);
+    caze.setAddressType(ADDRESS_TYPE_TEST);
 
     caze.setUacQidLinks(null);
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import org.json.JSONArray;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
-import uk.gov.ons.census.caseapisvc.model.dto.CaseIdDto;
+import uk.gov.ons.census.caseapisvc.model.dto.CaseIdAddressTypeDto;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
@@ -73,9 +73,9 @@ public class DataUtils {
     return mapper.readValue(response.getBody().getObject().toString(), CaseContainerDTO.class);
   }
 
-  public static CaseIdDto extractCaseIdDtoFromResponse(HttpResponse<JsonNode> response)
+  public static CaseIdAddressTypeDto extractCaseIdDtoFromResponse(HttpResponse<JsonNode> response)
       throws IOException {
-    return mapper.readValue(response.getBody().getObject().toString(), CaseIdDto.class);
+    return mapper.readValue(response.getBody().getObject().toString(), CaseIdAddressTypeDto.class);
   }
 
   public static List<CaseContainerDTO> extractCaseContainerDTOsFromResponse(


### PR DESCRIPTION
# Motivation and Context
The ActionCancel msg was faulty, missing addressType

# What has changed
The find by QID endpoint now also returns addressType

# How to test?
With the related ATs and fwmtadapter, set up all locally and run tests

# Links
https://trello.com/c/B7P71yDJ/1042-cancel-refusal-message-to-the-field-is-incorrect

# Screenshots (if appropriate):