### PR TITLE
Add constructor for QidNotFoundException with caseId

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/exception/QidNotFoundException.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/exception/QidNotFoundException.java
@@ -1,7 +1,12 @@
 package uk.gov.ons.census.caseapisvc.exception;
 
+import java.util.UUID;
+
 public class QidNotFoundException extends RuntimeException {
   public QidNotFoundException(String qid) {
     super(String.format("Qid Not Found '%s' not found", qid));
+  }
+  public QidNotFoundException(UUID caseId) {
+    super(String.format("Qid Not Found for case ID: '%s'", caseId));
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/exception/QidNotFoundException.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/exception/QidNotFoundException.java
@@ -6,6 +6,7 @@ public class QidNotFoundException extends RuntimeException {
   public QidNotFoundException(String qid) {
     super(String.format("Qid Not Found '%s' not found", qid));
   }
+
   public QidNotFoundException(UUID caseId) {
     super(String.format("Qid Not Found for case ID: '%s'", caseId));
   }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -69,7 +69,7 @@ public class CaseService {
     UUID caseIdUUID = validateAndConvertCaseIdToUUID(caseId);
     return uacQidLinkRepository
         .findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(caseIdUUID)
-        .orElseThrow(() -> new QidNotFoundException(caseId))
+        .orElseThrow(() -> new QidNotFoundException(caseIdUUID))
         .getQid();
   }
 


### PR DESCRIPTION
# Motivation and Context
The exception was being passed a case ID instead of a QID it was excepting

# What has changed
* Add constructor for QidNotFoundException to accept a UUID case ID

# How to test?
Request a the CCS QID for a bogus case ID, you should get a less non-sensical response.

# Links
https://trello.com/c/T1k3bNPn/1121-implement-field-ccs-eq-launch-5