### PR TITLE
Set active flag on CCS QID response

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -93,9 +93,10 @@ public final class CaseEndpoint {
   @GetMapping(value = "/ccs/{caseId}/qid")
   public QidDTO findCCSQidByCaseId(@PathVariable("caseId") String caseId) {
     log.debug("Entering findByCaseId");
-    String ccsQid = caseService.findCcsQidByCaseId(caseId);
+    UacQidLink ccsUacQidLink = caseService.findUacQidLinkByCaseId(caseId);
     QidDTO qidDTO = new QidDTO();
-    qidDTO.setQid(ccsQid);
+    qidDTO.setQid(ccsUacQidLink.getQid());
+    qidDTO.setActive(ccsUacQidLink.isActive());
     return qidDTO;
   }
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/QidDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/QidDTO.java
@@ -5,4 +5,5 @@ import lombok.Data;
 @Data
 public class QidDTO {
   private String qid;
+  private boolean active;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -65,12 +65,11 @@ public class CaseService {
     return uacQidLink.getCaze();
   }
 
-  public String findCcsQidByCaseId(String caseId) {
+  public UacQidLink findUacQidLinkByCaseId(String caseId) {
     UUID caseIdUUID = validateAndConvertCaseIdToUUID(caseId);
     return uacQidLinkRepository
         .findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(caseIdUUID)
-        .orElseThrow(() -> new QidNotFoundException(caseIdUUID))
-        .getQid();
+        .orElseThrow(() -> new QidNotFoundException(caseIdUUID));
   }
 
   private UUID validateAndConvertCaseIdToUUID(String caseId) {

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
@@ -156,8 +156,10 @@ public class CaseServiceTest {
             UUID.fromString(TEST_CASE_ID_EXISTS)))
         .thenReturn(Optional.of(ccsUacQidLink));
 
-    String actualCcsQid = caseService.findCcsQidByCaseId(ccsCase.getCaseId().toString());
-    assertThat(actualCcsQid).isEqualTo(TEST_CCS_QID);
+    UacQidLink actualCcsUacQidLink =
+        caseService.findUacQidLinkByCaseId(ccsCase.getCaseId().toString());
+    assertThat(actualCcsUacQidLink.getQid()).isEqualTo(TEST_CCS_QID);
+    assertThat(actualCcsUacQidLink.isActive()).isEqualTo(true);
   }
 
   @Test(expected = QidNotFoundException.class)
@@ -165,6 +167,6 @@ public class CaseServiceTest {
     when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(
             UUID.fromString(TEST_CASE_ID_DOES_NOT_EXIST)))
         .thenReturn(Optional.empty());
-    caseService.findCcsQidByCaseId(TEST_CASE_ID_EXISTS);
+    caseService.findUacQidLinkByCaseId(TEST_CASE_ID_EXISTS);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -76,7 +76,7 @@ public class DataUtils {
   public static Case createCcsCase(UUID caseId, int caseRef, String qid) {
     List<UacQidLink> uacQidLinks = new LinkedList<>();
 
-    UacQidLink uacQidLink = createCcsUacQidLink(qid);
+    UacQidLink uacQidLink = createCcsUacQidLink(qid, true);
     uacQidLinks.add(uacQidLink);
 
     Case caze = new Case();
@@ -87,12 +87,13 @@ public class DataUtils {
     return caze;
   }
 
-  public static UacQidLink createCcsUacQidLink(String qid) {
+  public static UacQidLink createCcsUacQidLink(String qid, boolean active) {
     UacQidLink ccsUacQidLink = new UacQidLink();
     ccsUacQidLink.setId(UUID.randomUUID());
     ccsUacQidLink.setUac("any UAC");
     ccsUacQidLink.setQid(qid);
     ccsUacQidLink.setCcsCase(true);
+    ccsUacQidLink.setActive(active);
     return ccsUacQidLink;
   }
 


### PR DESCRIPTION
# Motivation and Context
The active flag is now required in the response from the CCS QID endpoint

# What has changed
* Set active flag on CCS QID response
* Tests

# How to test?
Run with linked branch of acceptance tests

# Links
https://trello.com/c/BveqdONB/1253-return-qid-active-status-on-field-eq-launch-api-3
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/138