### PR TITLE
New fields on case api

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -32,7 +32,10 @@ import uk.gov.ons.census.caseapisvc.service.CaseService;
 @RestController
 @RequestMapping(value = "/cases")
 public final class CaseEndpoint {
+
   private static final Logger log = LoggerFactory.getLogger(CaseEndpoint.class);
+  private static final String CENSUS_SURVEY_TYPE = "CENSUS";
+  private static final String CCS_SURVEY_TYPE = "CCS";
 
   private final CaseService caseService;
   private final MapperFacade mapperFacade;
@@ -114,6 +117,8 @@ public final class CaseEndpoint {
   private CaseContainerDTO buildCaseContainerDTO(Case caze, boolean includeCaseEvents) {
 
     CaseContainerDTO caseContainerDTO = this.mapperFacade.map(caze, CaseContainerDTO.class);
+    caseContainerDTO.setSurveyType(getSurveyType(caze));
+
     List<EventDTO> caseEvents = new LinkedList<>();
 
     if (includeCaseEvents) {
@@ -136,5 +141,14 @@ public final class CaseEndpoint {
     caseContainerDTO.setCaseEvents(caseEvents);
 
     return caseContainerDTO;
+  }
+
+  private String getSurveyType(Case caze) {
+
+    if (caze.isCcsCase()) {
+      return CCS_SURVEY_TYPE;
+    }
+
+    return CENSUS_SURVEY_TYPE;
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -21,6 +21,10 @@ public class CaseContainerDTO {
 
   private String uprn;
 
+  private String collectionExerciseId;
+
+  private String surveyType;
+
   @JsonProperty("caseType")
   private String addressType;
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -32,6 +32,7 @@ import uk.gov.ons.census.caseapisvc.exception.CaseIdNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.CaseReferenceNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.QidNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.UPRNNotFoundException;
+import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 import uk.gov.ons.census.caseapisvc.service.CaseService;
 
@@ -157,7 +158,27 @@ public class CaseEndpointUnitTest {
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(handler().methodName(METHOD_NAME_FIND_CASE_BY_ID))
         .andExpect(jsonPath("$.id", is(TEST1_CASE_ID)))
-        .andExpect(jsonPath("$.caseEvents", hasSize(0)));
+        .andExpect(jsonPath("$.caseEvents", hasSize(0)))
+        .andExpect(jsonPath("$.surveyType", is("CENSUS")));
+  }
+
+  @Test
+  public void getACaseWithoutEventsByCaseIdForCCSCase() throws Exception {
+    Case testCase = createSingleCaseWithEvents();
+    testCase.setCcsCase(true);
+    when(caseService.findByCaseId(any())).thenReturn(testCase);
+
+    mockMvc
+        .perform(
+            get(createUrl("/cases/%s", TEST1_CASE_ID))
+                .param("caseEvents", "false")
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CaseEndpoint.class))
+        .andExpect(handler().methodName(METHOD_NAME_FIND_CASE_BY_ID))
+        .andExpect(jsonPath("$.id", is(TEST1_CASE_ID)))
+        .andExpect(jsonPath("$.caseEvents", hasSize(0)))
+        .andExpect(jsonPath("$.surveyType", is("CCS")));
   }
 
   @Test

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -137,6 +137,13 @@
       "durable": true,
       "auto_delete": false,
       "arguments": {}
+    },
+    {
+      "name": "dummy.uac-qid-created",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
     }
   ],
   "exchanges": [

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-case-api-it:5432/postgres?sslmode=disable
       - SPRING_RABBITMQ_HOST=rabbitmq-case-api-it
       - SPRING_RABBITMQ_PORT=5672
+      - QUEUECONFIG_UAC_QID_CREATED_QUEUE=dummy.uac-qid-created
       - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121 -Dspring.profiles.active=dev
     healthcheck:
       test: ["CMD", "cat", "/tmp/case-service-healthy"]


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Two extra fields need to be returned from case-api, collectionExerciseId and surveyType(inferred from ccs_case boolean).

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
collectionExerciseId added to DTO and surveyType set using the ccs_case flag on the case.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build this branch and test with acceptance tests branch of the [same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/141). Alternatively use postman to submit requests to case-api checking returned json contains the new fields.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/BGuOGSeR/1263-new-fields-on-case-api-5
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/141
# Screenshots (if appropriate):