### PR TITLE
Fix incorrect DTO qid key

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -98,7 +98,7 @@ public final class CaseEndpoint {
     log.debug("Entering findByCaseId");
     UacQidLink ccsUacQidLink = caseService.findUacQidLinkByCaseId(caseId);
     QidDTO qidDTO = new QidDTO();
-    qidDTO.setQid(ccsUacQidLink.getQid());
+    qidDTO.setQuestionnaireId(ccsUacQidLink.getQid());
     qidDTO.setActive(ccsUacQidLink.isActive());
     return qidDTO;
   }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/QidDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/QidDTO.java
@@ -4,6 +4,6 @@ import lombok.Data;
 
 @Data
 public class QidDTO {
-  private String qid;
+  private String questionnaireId;
   private boolean active;
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -324,7 +324,7 @@ public class CaseEndpointIT {
 
     QidDTO actualQidDTO =
         DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), QidDTO.class);
-    assertThat(actualQidDTO.getQid()).isEqualTo(DataUtils.TEST_CCS_QID);
+    assertThat(actualQidDTO.getQuestionnaireId()).isEqualTo(DataUtils.TEST_CCS_QID);
     assertThat(actualQidDTO.isActive()).isTrue();
   }
 
@@ -341,7 +341,7 @@ public class CaseEndpointIT {
 
     QidDTO actualQidDTO =
         DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), QidDTO.class);
-    assertThat(actualQidDTO.getQid()).isEqualTo(DataUtils.TEST_CCS_QID);
+    assertThat(actualQidDTO.getQuestionnaireId()).isEqualTo(DataUtils.TEST_CCS_QID);
     assertThat(actualQidDTO.isActive()).isFalse();
   }
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -282,7 +282,7 @@ public class CaseEndpointUnitTest {
             get(createUrl("/cases/ccs/%s/qid", TEST1_CASE_ID)).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
-        .andExpect(jsonPath("$.qid", is(TEST_CCS_QID)))
+        .andExpect(jsonPath("$.questionnaireId", is(TEST_CCS_QID)))
         .andExpect(jsonPath("$.active", is(true)));
   }
 
@@ -296,7 +296,7 @@ public class CaseEndpointUnitTest {
             get(createUrl("/cases/ccs/%s/qid", TEST1_CASE_ID)).accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
-        .andExpect(jsonPath("$.qid", is(TEST_CCS_QID)))
+        .andExpect(jsonPath("$.questionnaireId", is(TEST_CCS_QID)))
         .andExpect(jsonPath("$.active", is(false)));
   }
 


### PR DESCRIPTION
# Motivation and Context
The `qid` JSON key does not match the API spec, it should be `questionnaireId`

# What has changed
* Fix qid JSON key to match spec

# How to test?
Build and run this branch against linked acceptance test branch

# Links
https://trello.com/c/PaAl8jVl/1353-defect-case-api-for-ccs-to-get-qid-doesnt-match-spec
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/143