### PR TITLE
Model changes for fpe case ref

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -3,7 +3,6 @@ package uk.gov.ons.census.caseapisvc.model.entity;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
-import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -12,23 +11,30 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import lombok.Data;
+import org.hibernate.annotations.Generated;
+import org.hibernate.annotations.GenerationTime;
 
 @Data
 @Entity
 @Table(name = "cases")
 public class Case {
 
-  @Id private int caseRef;
+  @Id private UUID caseId;
 
-  @Column private UUID caseId;
+  // This bad boy allows us to ge;nerate a pseudorandom unique (non-colliding) caseRef
+  @Column(columnDefinition = "serial")
+  @Generated(GenerationTime.INSERT)
+  private int secretSequenceNumber;
 
-  @Column private String caseType;
+  @Column private Integer caseRef;
 
   @Column private String arid;
 
   @Column private String estabArid;
 
   @Column private String uprn;
+
+  @Column private String caseType;
 
   @Column private String addressType;
 
@@ -87,9 +93,7 @@ public class Case {
   @Enumerated(EnumType.STRING)
   private CaseState state;
 
-  @OneToMany(
-      mappedBy = "caze",
-      cascade = {CascadeType.ALL})
+  @OneToMany(mappedBy = "caze")
   List<UacQidLink> uacQidLinks;
 
   @OneToMany(mappedBy = "caze")
@@ -103,6 +107,9 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean addressInvalid;
+
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
+  private boolean undeliveredAsAddressed;
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean ccsCase;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/EventRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/EventRepository.java
@@ -1,0 +1,7 @@
+package uk.gov.ons.census.caseapisvc.model.repository;
+
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+import uk.gov.ons.census.caseapisvc.model.entity.Event;
+
+public interface EventRepository extends JpaRepository<Event, UUID> {}

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - SPRING_RABBITMQ_PORT=5672
       - QUEUECONFIG_UAC_QID_CREATED_QUEUE=dummy.uac-qid-created
       - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121 -Dspring.profiles.active=dev
+      - HMACKEY=12, 32, 24, 32, 13, 32, 5, 32
     healthcheck:
       test: ["CMD", "cat", "/tmp/case-service-healthy"]
       interval: 30s

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       - SPRING_RABBITMQ_PORT=5672
       - QUEUECONFIG_UAC_QID_CREATED_QUEUE=dummy.uac-qid-created
       - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121 -Dspring.profiles.active=dev
-      - HMACKEY=12, 32, 24, 32, 13, 32, 5, 32
+      - CASEREFGENERATORKEY=6+VLkvz5XYkF7vFLVX7FDnfxavQ7M+iY
     healthcheck:
       test: ["CMD", "cat", "/tmp/case-service-healthy"]
       interval: 30s


### PR DESCRIPTION
# Motivation and Context
CaseRef now generated with fixed format encryption, need a new model for this, so case-api needs to be updated to match it.

# What has changed
Case Entity changed, some tests altered to continue working

# How to test?
Should work with the case-processor branch: https://github.com/ONSdigital/census-rm-case-processor/tree/pseudorandom_case_ref_for_2021

# Links
https://trello.com/c/e9UNd6NM/354-2021-performance-caseref-pseudorandom-productionisation-13

# Screenshots (if appropriate):