### PR TITLE
Refactor CCS features (Part 1)

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -34,8 +34,6 @@ import uk.gov.ons.census.caseapisvc.service.CaseService;
 public final class CaseEndpoint {
 
   private static final Logger log = LoggerFactory.getLogger(CaseEndpoint.class);
-  private static final String CENSUS_SURVEY_TYPE = "CENSUS";
-  private static final String CCS_SURVEY_TYPE = "CCS";
 
   private final CaseService caseService;
   private final MapperFacade mapperFacade;
@@ -117,7 +115,7 @@ public final class CaseEndpoint {
   private CaseContainerDTO buildCaseContainerDTO(Case caze, boolean includeCaseEvents) {
 
     CaseContainerDTO caseContainerDTO = this.mapperFacade.map(caze, CaseContainerDTO.class);
-    caseContainerDTO.setSurveyType(getSurveyType(caze));
+    caseContainerDTO.setSurveyType(caze.getSurvey());
 
     List<EventDTO> caseEvents = new LinkedList<>();
 
@@ -141,14 +139,5 @@ public final class CaseEndpoint {
     caseContainerDTO.setCaseEvents(caseEvents);
 
     return caseContainerDTO;
-  }
-
-  private String getSurveyType(Case caze) {
-
-    if (caze.isCcsCase()) {
-      return CCS_SURVEY_TYPE;
-    }
-
-    return CENSUS_SURVEY_TYPE;
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -94,7 +94,7 @@ public final class CaseEndpoint {
   @GetMapping(value = "/ccs/{caseId}/qid")
   public QidDTO findCCSQidByCaseId(@PathVariable("caseId") String caseId) {
     log.debug("Entering findByCaseId");
-    UacQidLink ccsUacQidLink = caseService.findUacQidLinkByCaseId(caseId);
+    UacQidLink ccsUacQidLink = caseService.findCCSUacQidLinkByCaseId(caseId);
     QidDTO qidDTO = new QidDTO();
     qidDTO.setQuestionnaireId(ccsUacQidLink.getQid());
     qidDTO.setActive(ccsUacQidLink.isActive());

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -86,6 +86,9 @@ public class Case {
 
   @Column private String actionPlanId;
 
+  @Column(nullable = false)
+  private String survey;
+
   @Column(columnDefinition = "timestamp with time zone")
   private OffsetDateTime createdDateTime;
 
@@ -111,6 +114,4 @@ public class Case {
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
 
-  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
-  private boolean ccsCase;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -115,5 +115,4 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
-
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/UacQidLinkRepository.java
@@ -8,5 +8,5 @@ import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {
   Optional<UacQidLink> findByQid(String qid);
 
-  Optional<UacQidLink> findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(UUID caseId);
+  Optional<UacQidLink> findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(UUID caseIdUUID, String survey);
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/UacQidLinkRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/UacQidLinkRepository.java
@@ -8,5 +8,6 @@ import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 public interface UacQidLinkRepository extends JpaRepository<UacQidLink, UUID> {
   Optional<UacQidLink> findByQid(String qid);
 
-  Optional<UacQidLink> findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(UUID caseIdUUID, String survey);
+  Optional<UacQidLink> findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(
+      UUID caseIdUUID, String survey);
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -68,7 +68,7 @@ public class CaseService {
   public UacQidLink findUacQidLinkByCaseId(String caseId) {
     UUID caseIdUUID = validateAndConvertCaseIdToUUID(caseId);
     return uacQidLinkRepository
-        .findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(caseIdUUID)
+        .findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(caseIdUUID, "CCS")
         .orElseThrow(() -> new QidNotFoundException(caseIdUUID));
   }
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -65,7 +65,7 @@ public class CaseService {
     return uacQidLink.getCaze();
   }
 
-  public UacQidLink findUacQidLinkByCaseId(String caseId) {
+  public UacQidLink findCCSUacQidLinkByCaseId(String caseId) {
     UUID caseIdUUID = validateAndConvertCaseIdToUUID(caseId);
     return uacQidLinkRepository
         .findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(caseIdUUID, "CCS")

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -445,11 +445,11 @@ public class CaseEndpointIT {
   }
 
   private Case setupTestCaseWithoutEvents(String caseId) {
-    return setupTestCaseWithoutEvents(caseId, false);
+    return setupTestCaseWithoutEvents(caseId, "CENSUS");
   }
 
   private Case setupTestCcsCaseWithoutEvents(String caseId) {
-    return setupTestCaseWithoutEvents(caseId, true);
+    return setupTestCaseWithoutEvents(caseId, "CCS");
   }
 
   private Case getaCase(String caseId) {
@@ -484,9 +484,9 @@ public class CaseEndpointIT {
     uacQidLinkRepository.saveAndFlush(uacQidLink);
   }
 
-  private Case setupTestCaseWithoutEvents(String caseId, boolean ccsCase) {
+  private Case setupTestCaseWithoutEvents(String caseId, String survey) {
     Case caze = getaCase(caseId);
-    caze.setCcsCase(ccsCase);
+    caze.setSurvey(survey);
 
     caseRepo.saveAndFlush(caze);
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -165,7 +165,7 @@ public class CaseEndpointUnitTest {
   @Test
   public void getACaseWithoutEventsByCaseIdForCCSCase() throws Exception {
     Case testCase = createSingleCaseWithEvents();
-    testCase.setCcsCase(true);
+    testCase.setSurvey("CCS");
     when(caseService.findByCaseId(any())).thenReturn(testCase);
 
     mockMvc

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -302,7 +302,8 @@ public class CaseEndpointUnitTest {
 
   @Test
   public void getCcsQidByCaseIdCcsCaseNotFound() throws Exception {
-    when(caseService.findCCSUacQidLinkByCaseId(any())).thenThrow(new CaseIdNotFoundException("test"));
+    when(caseService.findCCSUacQidLinkByCaseId(any()))
+        .thenThrow(new CaseIdNotFoundException("test"));
 
     mockMvc
         .perform(

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -275,7 +275,7 @@ public class CaseEndpointUnitTest {
   @Test
   public void getCcsQidByCaseId() throws Exception {
     UacQidLink ccsUacQidLink = createCcsUacQidLink(TEST_CCS_QID, true);
-    when(caseService.findUacQidLinkByCaseId(any())).thenReturn(ccsUacQidLink);
+    when(caseService.findCCSUacQidLinkByCaseId(any())).thenReturn(ccsUacQidLink);
 
     mockMvc
         .perform(
@@ -289,7 +289,7 @@ public class CaseEndpointUnitTest {
   @Test
   public void getInactiveCcsQidByCaseId() throws Exception {
     UacQidLink ccsUacQidLink = createCcsUacQidLink(TEST_CCS_QID, false);
-    when(caseService.findUacQidLinkByCaseId(any())).thenReturn(ccsUacQidLink);
+    when(caseService.findCCSUacQidLinkByCaseId(any())).thenReturn(ccsUacQidLink);
 
     mockMvc
         .perform(
@@ -302,7 +302,7 @@ public class CaseEndpointUnitTest {
 
   @Test
   public void getCcsQidByCaseIdCcsCaseNotFound() throws Exception {
-    when(caseService.findUacQidLinkByCaseId(any())).thenThrow(new CaseIdNotFoundException("test"));
+    when(caseService.findCCSUacQidLinkByCaseId(any())).thenThrow(new CaseIdNotFoundException("test"));
 
     mockMvc
         .perform(
@@ -313,7 +313,7 @@ public class CaseEndpointUnitTest {
 
   @Test
   public void getCcsQidByCaseIdCcsQIDNotFound() throws Exception {
-    when(caseService.findUacQidLinkByCaseId(any())).thenThrow(new QidNotFoundException("test"));
+    when(caseService.findCCSUacQidLinkByCaseId(any())).thenThrow(new QidNotFoundException("test"));
 
     mockMvc
         .perform(

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
@@ -152,8 +152,8 @@ public class CaseServiceTest {
   public void testFindCcsQidByCaseId() {
     Case ccsCase = createSingleCcsCaseWithCcsQid();
     UacQidLink ccsUacQidLink = ccsCase.getUacQidLinks().get(0);
-    when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(
-            UUID.fromString(TEST_CASE_ID_EXISTS)))
+    when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(
+            UUID.fromString(TEST_CASE_ID_EXISTS), "CCS"))
         .thenReturn(Optional.of(ccsUacQidLink));
 
     UacQidLink actualCcsUacQidLink =
@@ -164,8 +164,8 @@ public class CaseServiceTest {
 
   @Test(expected = QidNotFoundException.class)
   public void testFindCcsQidByCaseIdNoCcsQidFound() {
-    when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeCcsCaseIsTrue(
-            UUID.fromString(TEST_CASE_ID_DOES_NOT_EXIST)))
+    when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(
+            UUID.fromString(TEST_CASE_ID_DOES_NOT_EXIST), "CCS"))
         .thenReturn(Optional.empty());
     caseService.findUacQidLinkByCaseId(TEST_CASE_ID_EXISTS);
   }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
@@ -157,7 +157,7 @@ public class CaseServiceTest {
         .thenReturn(Optional.of(ccsUacQidLink));
 
     UacQidLink actualCcsUacQidLink =
-        caseService.findUacQidLinkByCaseId(ccsCase.getCaseId().toString());
+        caseService.findCCSUacQidLinkByCaseId(ccsCase.getCaseId().toString());
     assertThat(actualCcsUacQidLink.getQid()).isEqualTo(TEST_CCS_QID);
     assertThat(actualCcsUacQidLink.isActive()).isEqualTo(true);
   }
@@ -167,6 +167,6 @@ public class CaseServiceTest {
     when(uacQidLinkRepository.findOneByCcsCaseIsTrueAndCazeCaseIdAndCazeSurvey(
             UUID.fromString(TEST_CASE_ID_DOES_NOT_EXIST), "CCS"))
         .thenReturn(Optional.empty());
-    caseService.findUacQidLinkByCaseId(TEST_CASE_ID_EXISTS);
+    caseService.findCCSUacQidLinkByCaseId(TEST_CASE_ID_EXISTS);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -69,6 +69,7 @@ public class DataUtils {
     caze.setCaseId(caseId);
     caze.setUprn(TEST_UPRN);
     caze.setUacQidLinks(uacQidLinks);
+    caze.setSurvey("CENSUS");
 
     return caze;
   }
@@ -83,6 +84,7 @@ public class DataUtils {
     caze.setCaseRef(caseRef);
     caze.setCaseId(caseId);
     caze.setUacQidLinks(uacQidLinks);
+    caze.setSurvey("CCS");
 
     return caze;
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now that the `isCCS` flag has been removed from the cases table, we need to change the way the case-api can retrieve CCS cases from its end-point. We can do this with the `survey` column instead.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Changed the ccs endpoint to retrieve CCS cases by `survey` instead of the CCS flag.
* Updated existing tests

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
NOTE: Travis build is currently failing due to new cases table column `survey` added by case-processor. This is to be expected until the case-processor PR has been merged

Run the tests, or create some CCS cases, make a note of their case IDs, try hitting the CCS endpoint to retrieve their details with `GET /cases/ccs/<case_ID>/qid`

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/4gq2Ufvz/411-refactor-ccs-features-part-one-13
