### PR TITLE
RMC-335 Telephone capture for HH cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ All endpoints include an optional `caseevents` boolean query parameter (default 
 
 If this query parameter is omitted these case events **will not** be returned with the case details. 
 
-### Example case JSON response
+### Example Case JSON Response
 ```json
 {
   "abpCode": "RD06",
@@ -59,7 +59,7 @@ If this query parameter is omitted these case events **will not** be returned wi
 
 * `POST /uacqid/create`
 
-### Example request body
+### Example Request Rody
 ```json
 {
 "caseId": "820c9ebc-ac8c-483c-a9ec-0c2546d15d01",
@@ -67,7 +67,7 @@ If this query parameter is omitted these case events **will not** be returned wi
 }
 ```
 
-### Example JSON response
+### Example UAC QID JSON Response
 ```json
 {
   "caseId": "820c9ebc-ac8c-483c-a9ec-0c2546d15d01",
@@ -79,7 +79,7 @@ If this query parameter is omitted these case events **will not** be returned wi
 * `GET /cases/<case_id>/qid` 
     Returns a newly generated QID/UAC pair every time based on the case type and links it to the case by eventual consistency (not synchronously)
 
-### Example UAC QID Link JSON Response
+### Example UAC QID JSON Response
 ```json
 {
   "qid": "0120000000000200",
@@ -92,7 +92,7 @@ If this query parameter is omitted these case events **will not** be returned wi
 * `GET /cases/ccs/<case_id>/qid` 
     Returns the single assigned CCS telephone capture QID for a CCS case
 
-### Example CCS QID JSON response
+### Example CCS QID JSON Response
 ```json
 {
   "active": "True",

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This case api service provides a range of Restful endpoints that -
 The service relies on, and makes no changes to the casev2 schema maintained by census-rm-case-processor 
 
 # Endpoints
-## Endpoints that return case details:
+## Case details:
 
 * `GET /cases/uprn/<uprn>` (returns a list)
 * `GET /cases/<case_id>`
@@ -22,7 +22,7 @@ All endpoints include an optional `caseevents` boolean query parameter (default 
 
 If this query parameter is omitted these case events **will not** be returned with the case details. 
 
-### Example Case JSON Response
+### Example case JSON response
 ```json
 {
   "abpCode": "RD06",
@@ -55,11 +55,19 @@ If this query parameter is omitted these case events **will not** be returned wi
 }
 ```
 
-## Endpoint that returns a QID:
+## Create, return and link a new UAC QID pair for a case:
 
-* `GET /cases/ccs/<case_id>/qid`
+* `POST /uacqid/create`
 
-### Example QID JSON Response
+### Example request body
+```json
+{
+"caseId": "820c9ebc-ac8c-483c-a9ec-0c2546d15d01",
+"questionnaireType": "01"
+}
+```
+
+### Example JSON response
 ```json
 {
   "caseId": "820c9ebc-ac8c-483c-a9ec-0c2546d15d01",
@@ -68,11 +76,23 @@ If this query parameter is omitted these case events **will not** be returned wi
 }
 ```
 
-## Endpoint that creates and returns a new Uac QID Link:
-
-* `GET /uacqid/create`
+* `GET /cases/<case_id>/qid` 
+    Returns a newly generated QID/UAC pair every time based on the case type and links it to the case by eventual consistency (not synchronously)
 
 ### Example UAC QID Link JSON Response
+```json
+{
+  "qid": "0120000000000200",
+  "uac": "f7hhksdgtk4vj59h"
+}
+```
+
+## CCS QID:
+
+* `GET /cases/ccs/<case_id>/qid` 
+    Returns the single assigned CCS telephone capture QID for a CCS case
+
+### Example CCS QID JSON response
 ```json
 {
   "active": "True",

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
@@ -8,10 +8,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import uk.gov.ons.census.caseapisvc.client.UacQidServiceClient;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseDetailsDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
-import uk.gov.ons.census.caseapisvc.service.UacQidDistributor;
+import uk.gov.ons.census.caseapisvc.service.UacQidService;
 
 @RestController
 @RequestMapping(value = "/uacqid")
@@ -19,13 +18,10 @@ public class UacQidEndpoint {
 
   private static final Logger log = LoggerFactory.getLogger(UacQidEndpoint.class);
 
-  private final UacQidServiceClient uacQidServiceClient;
-  private final UacQidDistributor uacQidDistributor;
+  private final UacQidService uacQidService;
 
-  public UacQidEndpoint(
-      UacQidServiceClient uacQidServiceClient, UacQidDistributor uacQidDistributor) {
-    this.uacQidServiceClient = uacQidServiceClient;
-    this.uacQidDistributor = uacQidDistributor;
+  public UacQidEndpoint(UacQidService uacQidService) {
+    this.uacQidService = uacQidService;
   }
 
   @PostMapping(path = "/create", consumes = "application/json", produces = "application/json")
@@ -34,9 +30,7 @@ public class UacQidEndpoint {
     int questionnaireType = Integer.parseInt(caseDetails.getQuestionnaireType());
     log.with("caseId", caseDetails.getCaseId()).debug("Generating UAC QID pair for case");
     UacQidCreatedPayloadDTO uacQidCreatedPayload =
-        uacQidServiceClient.generateUacQid(questionnaireType);
-    uacQidCreatedPayload.setCaseId(caseDetails.getCaseId().toString());
-    uacQidDistributor.sendUacQidCreatedEvent(uacQidCreatedPayload);
+        uacQidService.createAndLinkUacQid(caseDetails.getCaseId().toString(), questionnaireType);
     return ResponseEntity.status(HttpStatus.CREATED).body(uacQidCreatedPayload);
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/UacQidDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/UacQidDTO.java
@@ -1,0 +1,9 @@
+package uk.gov.ons.census.caseapisvc.model.dto;
+
+import lombok.Data;
+
+@Data
+public class UacQidDTO {
+  private String questionnaireId;
+  private String uac;
+}

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpointIT.java
@@ -22,6 +22,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
@@ -70,6 +71,7 @@ public class UacQidEndpointIT {
   }
 
   @Test
+  @DirtiesContext
   public void shouldDistributeUacQidCreatedEvent()
       throws UnirestException, IOException, InterruptedException {
     // Given

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpointUnitTest.java
@@ -1,13 +1,11 @@
 package uk.gov.ons.census.caseapisvc.endpoint;
 
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.UUID;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.InjectMocks;
@@ -16,9 +14,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.gov.ons.census.caseapisvc.client.UacQidServiceClient;
 import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
-import uk.gov.ons.census.caseapisvc.service.UacQidDistributor;
+import uk.gov.ons.census.caseapisvc.service.UacQidService;
 
 public class UacQidEndpointUnitTest {
 
@@ -26,11 +23,7 @@ public class UacQidEndpointUnitTest {
 
   private MockMvc mockMvc;
 
-  @Mock private UacQidServiceClient uacQidServiceClient;
-
-  @Mock
-  @SuppressWarnings("unused")
-  private UacQidDistributor uacQidDistributor;
+  @Mock private UacQidService uacQidService;
 
   @InjectMocks private UacQidEndpoint uacQidEndpoint;
 
@@ -41,11 +34,6 @@ public class UacQidEndpointUnitTest {
     this.mockMvc = MockMvcBuilders.standaloneSetup(uacQidEndpoint).build();
   }
 
-  @After
-  public void tearDown() {
-    reset(uacQidServiceClient);
-  }
-
   @Test
   public void createUacQidPair() throws Exception {
     UUID caseId = UUID.randomUUID();
@@ -53,7 +41,8 @@ public class UacQidEndpointUnitTest {
     uacQidCreatedPayloadDTO.setQid("0120000000005700");
     uacQidCreatedPayloadDTO.setUac("6ghnj22s5bp8r6rd");
     uacQidCreatedPayloadDTO.setCaseId(caseId.toString());
-    when(uacQidServiceClient.generateUacQid(1)).thenReturn(uacQidCreatedPayloadDTO);
+    when(uacQidService.createAndLinkUacQid(caseId.toString(), 1))
+        .thenReturn(uacQidCreatedPayloadDTO);
 
     mockMvc
         .perform(

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -90,6 +90,30 @@ public class UacQidServiceTest {
     assertThat(questionnaireType).isEqualTo(1);
   }
 
+  @Test
+  public void calculateQuestionnaireTypeForHouseholdWales() {
+    // Given
+    String treatmentCode = "HH_XXXXW";
+
+    // When
+    int questionnaireType = UacQidService.calculateQuestionnaireType(treatmentCode);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(2);
+  }
+
+  @Test
+  public void calculateQuestionnaireTypeForHouseholdNI() {
+    // Given
+    String treatmentCode = "HH_XXXXN";
+
+    // When
+    int questionnaireType = UacQidService.calculateQuestionnaireType(treatmentCode);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(4);
+  }
+
   @Test(expected = IllegalArgumentException.class)
   public void calculateQuestionnaireTypeUnKnownCaseType() {
     // Given

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -1,0 +1,110 @@
+package uk.gov.ons.census.caseapisvc.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static uk.gov.ons.census.caseapisvc.utility.DataUtils.CREATED_UAC;
+import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createUacQidCreatedPayload;
+
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Value;
+import uk.gov.ons.census.caseapisvc.client.UacQidServiceClient;
+import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedDTO;
+import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
+
+public class UacQidServiceTest {
+
+  @Value("${queueconfig.uac-qid-created-exchange}")
+  private String uacQidCreatedExchange;
+
+  private String NEW_QID = "newly created QID";
+  private int TEST_QUESTIONNAIRE_TYPE = 1;
+
+  @Mock private UacQidServiceClient uacQidServiceClient;
+  @Mock private RabbitTemplate rabbitTemplate;
+
+  @InjectMocks private UacQidService uacQidService;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+  }
+
+  @Test
+  public void createAndLinkUacQid() {
+    // Given
+    String caseId = UUID.randomUUID().toString();
+    when(uacQidServiceClient.generateUacQid(eq(TEST_QUESTIONNAIRE_TYPE)))
+        .thenReturn(createUacQidCreatedPayload(NEW_QID));
+
+    // When
+    UacQidCreatedPayloadDTO uacQidCreatedPayload =
+        uacQidService.createAndLinkUacQid(caseId, TEST_QUESTIONNAIRE_TYPE);
+
+    // Then
+    assertThat(uacQidCreatedPayload.getCaseId()).isEqualTo(caseId);
+    assertThat(uacQidCreatedPayload.getQid()).isEqualTo(NEW_QID);
+    assertThat(uacQidCreatedPayload.getUac()).isEqualTo(CREATED_UAC);
+  }
+
+  @Test
+  public void createAndLinkUacQidSendsRmUacCreatedEvent() {
+    // Given
+    String caseId = UUID.randomUUID().toString();
+    when(uacQidServiceClient.generateUacQid(eq(TEST_QUESTIONNAIRE_TYPE)))
+        .thenReturn(createUacQidCreatedPayload(NEW_QID));
+
+    // When
+    uacQidService.createAndLinkUacQid(caseId, TEST_QUESTIONNAIRE_TYPE);
+
+    // Then
+    ArgumentCaptor<UacQidCreatedDTO> uacQidCreatedCaptor =
+        ArgumentCaptor.forClass(UacQidCreatedDTO.class);
+    verify(rabbitTemplate)
+        .convertAndSend(eq(uacQidCreatedExchange), eq(""), uacQidCreatedCaptor.capture());
+    UacQidCreatedDTO sentUacQidCreatedDTO = uacQidCreatedCaptor.getValue();
+    assertThat(sentUacQidCreatedDTO.getEvent().getType()).isEqualTo("RM_UAC_CREATED");
+    assertThat(sentUacQidCreatedDTO.getPayload().getUacQidCreated().getCaseId()).isEqualTo(caseId);
+    assertThat(sentUacQidCreatedDTO.getPayload().getUacQidCreated().getQid()).isEqualTo(NEW_QID);
+    assertThat(sentUacQidCreatedDTO.getPayload().getUacQidCreated().getUac())
+        .isEqualTo(CREATED_UAC);
+  }
+
+  @Test
+  public void calculateQuestionnaireTypeForHouseholdEngland() {
+    // Given
+    String treatmentCode = "HH_XXXXE";
+
+    // When
+    int questionnaireType = UacQidService.calculateQuestionnaireType(treatmentCode);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(1);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void calculateQuestionnaireTypeUnKnownCaseType() {
+    // Given
+    String treatmentCode = "UN_XXXXE";
+
+    // When, then throws
+    UacQidService.calculateQuestionnaireType(treatmentCode);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void calculateQuestionnaireTypeUnKnownCountryCode() {
+    // Given
+    String treatmentCode = "HH_XXXXO";
+
+    // When, then throws
+    UacQidService.calculateQuestionnaireType(treatmentCode);
+  }
+}

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.UUID;
 import org.json.JSONArray;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
+import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
@@ -26,6 +27,7 @@ public class DataUtils {
   private static final String TEST_UPRN = "123";
 
   public static final String TEST_CCS_QID = "7120000000000000";
+  public static final String CREATED_UAC = "created UAC";
 
   public static final ObjectMapper mapper;
 
@@ -97,6 +99,19 @@ public class DataUtils {
     ccsUacQidLink.setCcsCase(true);
     ccsUacQidLink.setActive(active);
     return ccsUacQidLink;
+  }
+
+  public static UacQidCreatedPayloadDTO createUacQidCreatedPayload(String qid) {
+    UacQidCreatedPayloadDTO uacQidCreatedPayloadDTO = new UacQidCreatedPayloadDTO();
+    uacQidCreatedPayloadDTO.setQid(qid);
+    uacQidCreatedPayloadDTO.setUac(CREATED_UAC);
+    return uacQidCreatedPayloadDTO;
+  }
+
+  public static UacQidCreatedPayloadDTO createUacQidCreatedPayload(String qid, String caseId) {
+    UacQidCreatedPayloadDTO uacQidCreatedPayloadDTO = createUacQidCreatedPayload(qid);
+    uacQidCreatedPayloadDTO.setCaseId(caseId);
+    return uacQidCreatedPayloadDTO;
   }
 
   public static CaseContainerDTO extractCaseContainerDTOFromResponse(


### PR DESCRIPTION
# Motivation and Context
Telephone capture requires an endpoint to synchronously generate and return a new UAC/QID pair for a specified case. This new UAC/QID link also needs to be sent to the case processor for eventual data consistency. This is the same pattern as the existing UAC/QID endpoint but the caller only specifies a case ID and the service must work out the appropriate questionnaire type to request. This PR only implements the feature for HH household cases.

# What has changed
* Add endpoint to get and link a new UAC QID pair for a case
* Refactor UacQidDistributor into UacQidService
* Add tests

# How to test?
Build and run locally or in cloud environment. Run the linked AT's branch.

# Links
https://trello.com/c/J4Lo1jJl/464-rmc-335-telephone-capture-hh-8
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/152