### PR TITLE
add lastupdated to case entity to keep in sync with case processor

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -13,6 +13,7 @@ import javax.persistence.Table;
 import lombok.Data;
 import org.hibernate.annotations.Generated;
 import org.hibernate.annotations.GenerationTime;
+import org.hibernate.annotations.UpdateTimestamp;
 
 @Data
 @Entity
@@ -115,4 +116,6 @@ public class Case {
 
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
+
+  @Column @UpdateTimestamp private OffsetDateTime lastUpdated;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -117,5 +117,7 @@ public class Case {
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT false")
   private boolean undeliveredAsAddressed;
 
-  @Column @UpdateTimestamp private OffsetDateTime lastUpdated;
+  @Column(columnDefinition = "timestamp with time zone")
+  @UpdateTimestamp
+  private OffsetDateTime lastUpdated;
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Adding this lastUpdated time stamp will provide the capability to do 'delta' based extracts from RM for data that is sent to DAP for use by processing and the RCA/FPA algorithms as opposed to exported the full set each time.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
This is to match the changes to the Case entity that are in the case processor on a branch of the same name.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run maven clean install after running maven clean install on the caseprocessor branch.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/YHny5NEN/223-add-lastupdated-field-to-case-db-cases-table-3
# Screenshots (if appropriate):