### PR TITLE
Refactor so that new UAC-QID sent with fulfilment message

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -141,7 +141,7 @@ public final class CaseEndpoint {
         uacQidService.createAndLinkUacQid(caze.getCaseId().toString(), questionnaireType);
 
     caseService.buildAndSendTelephoneCaptureFulfilmentRequest(
-        caze.getCaseId().toString(), RM_TELEPHONE_CAPTURE, null);
+        caze.getCaseId().toString(), RM_TELEPHONE_CAPTURE, null, uacQidCreatedPayload);
     UacQidDTO uacQidDTO = new UacQidDTO();
     uacQidDTO.setQuestionnaireId(uacQidCreatedPayload.getQid());
     uacQidDTO.setUac(uacQidCreatedPayload.getUac());
@@ -164,7 +164,7 @@ public final class CaseEndpoint {
         uacQidService.createAndLinkUacQid(individualCaseId, questionnaireType);
 
     caseService.buildAndSendTelephoneCaptureFulfilmentRequest(
-        caseId, RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL, individualCaseId);
+        caseId, RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL, individualCaseId, uacQidCreatedPayload);
     UacQidDTO uacQidDTO = new UacQidDTO();
     uacQidDTO.setQuestionnaireId(uacQidCreatedPayload.getQid());
     uacQidDTO.setUac(uacQidCreatedPayload.getUac());

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
@@ -31,6 +31,7 @@ public class UacQidEndpoint {
     log.with("caseId", caseDetails.getCaseId()).debug("Generating UAC QID pair for case");
     UacQidCreatedPayloadDTO uacQidCreatedPayload =
         uacQidService.createAndLinkUacQid(caseDetails.getCaseId().toString(), questionnaireType);
+    uacQidService.sendUacQidCreatedEvent(uacQidCreatedPayload);
     return ResponseEntity.status(HttpStatus.CREATED).body(uacQidCreatedPayload);
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/FulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/FulfilmentRequestDTO.java
@@ -14,4 +14,6 @@ public class FulfilmentRequestDTO {
 
   @JsonInclude(Include.NON_NULL)
   private String individualCaseId;
+
+  private UacQidCreatedPayloadDTO uacQidCreated;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -20,6 +20,7 @@ import uk.gov.ons.census.caseapisvc.model.dto.EventDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.FulfilmentRequestDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.PayloadDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 import uk.gov.ons.census.caseapisvc.model.repository.CaseRepository;
@@ -110,10 +111,14 @@ public class CaseService {
   }
 
   public void buildAndSendTelephoneCaptureFulfilmentRequest(
-      String caseId, String fulfilmentCode, String individualCaseId) {
+      String caseId,
+      String fulfilmentCode,
+      String individualCaseId,
+      UacQidCreatedPayloadDTO uacQidCreated) {
     FulfilmentRequestDTO fulfilmentRequestDTO = new FulfilmentRequestDTO();
     fulfilmentRequestDTO.setCaseId(caseId);
     fulfilmentRequestDTO.setFulfilmentCode(fulfilmentCode);
+    fulfilmentRequestDTO.setUacQidCreated(uacQidCreated);
 
     EventDTO eventDTO = new EventDTO();
     eventDTO.setType(FULFILMENT_REQUEST_EVENT_TYPE);

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
@@ -34,11 +34,10 @@ public class UacQidService {
     UacQidCreatedPayloadDTO uacQidCreatedPayload =
         uacQidServiceClient.generateUacQid(questionnaireType);
     uacQidCreatedPayload.setCaseId(caseId);
-    sendUacQidCreatedEvent(uacQidCreatedPayload);
     return uacQidCreatedPayload;
   }
 
-  private void sendUacQidCreatedEvent(UacQidCreatedPayloadDTO uacQidPayload) {
+  public void sendUacQidCreatedEvent(UacQidCreatedPayloadDTO uacQidPayload) {
     EventDTO eventDTO = buildUacQidCreatedEventDTO();
     ResponseManagementEvent responseManagementEvent =
         buildUacQidCreatedDTO(eventDTO, uacQidPayload);

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -465,35 +465,6 @@ public class CaseEndpointIT {
   }
 
   @Test
-  @DirtiesContext
-  public void testGetNewUacQidForCaseDistributesUacCreatedEvent()
-      throws UnirestException, IOException, InterruptedException {
-    // Given
-    Case caze =
-        setupUnitTestCaseWithTreatmentCode(
-            TEST_CASE_ID_1_EXISTS, TEST_HOUSEHOLD_ENGLAND_TREATMENT_CODE);
-    BlockingQueue<String> uacQidCreatedQueue = rabbitQueueHelper.listen(uacQidCreatedQueueName);
-
-    // When
-    Unirest.get(createUrl("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
-        .header("accept", "application/json")
-        .asJson();
-
-    // Then
-    String message = rabbitQueueHelper.checkExpectedMessageReceived(uacQidCreatedQueue);
-    ResponseManagementEvent responseManagementEvent =
-        DataUtils.mapper.readValue(message, ResponseManagementEvent.class);
-
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getCaseId())
-        .isEqualTo(caze.getCaseId().toString());
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getQid()).startsWith("01");
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getUac()).isNotNull();
-    assertThat(responseManagementEvent.getEvent().getSource()).isEqualTo("RESPONSE_MANAGEMENT");
-    assertThat(responseManagementEvent.getEvent().getChannel()).isEqualTo("RM");
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo("RM_UAC_CREATED");
-  }
-
-  @Test
   public void testGetNewUacQidForCaseDoesNotReturnTheSameQidUacTwice()
       throws UnirestException, IOException {
     // Given
@@ -549,41 +520,61 @@ public class CaseEndpointIT {
 
   @Test
   @DirtiesContext
-  public void testGetNewIndividualUacQidForCaseDistributesUacCreatedEvent()
+  public void testGetNewUacQidForCaseDistributesFulfilmentEvent()
       throws UnirestException, IOException, InterruptedException {
     // Given
-    setupUnitTestCaseWithTreatmentCode(
-        TEST_CASE_ID_1_EXISTS, TEST_HOUSEHOLD_ENGLAND_TREATMENT_CODE);
-    UUID individualCaseId = UUID.randomUUID();
-    BlockingQueue<String> uacQidCreatedQueue = rabbitQueueHelper.listen(uacQidCreatedQueueName);
+    Case caze =
+        setupUnitTestCaseWithTreatmentCode(
+            TEST_CASE_ID_1_EXISTS, TEST_HOUSEHOLD_ENGLAND_TREATMENT_CODE);
+    BlockingQueue<String> caseFulfilmentQueue = rabbitQueueHelper.listen(caseFulfilmentsQueueName);
 
     // When
-    Unirest.get(
-            String.format(
-                "http://localhost:%d/cases/%s/qid?individual=true&individualCaseId=%s",
-                port, TEST_CASE_ID_1_EXISTS, individualCaseId.toString()))
-        .header("accept", "application/json")
-        .asJson();
+    HttpResponse<JsonNode> jsonResponse =
+        Unirest.get(createUrl("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
+            .header("accept", "application/json")
+            .asJson();
 
     // Then
-    String message = rabbitQueueHelper.checkExpectedMessageReceived(uacQidCreatedQueue);
+    UacQidDTO actualUacQidDTO =
+        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
+    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("01");
+    assertThat(actualUacQidDTO.getUac()).isNotNull();
+
+    String message = rabbitQueueHelper.checkExpectedMessageReceived(caseFulfilmentQueue);
     ResponseManagementEvent responseManagementEvent =
         DataUtils.mapper.readValue(message, ResponseManagementEvent.class);
 
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getCaseId())
-        .isEqualTo(individualCaseId.toString());
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getQid()).startsWith("21");
-    assertThat(responseManagementEvent.getPayload().getUacQidCreated().getUac()).isNotNull();
+    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode())
+        .isEqualTo("RM_TC");
+    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId())
+        .isEqualTo(caze.getCaseId().toString());
+    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId())
+        .isNull();
+
+    assertThat(
+            responseManagementEvent
+                .getPayload()
+                .getFulfilmentRequest()
+                .getUacQidCreated()
+                .getCaseId())
+        .isEqualTo(caze.getCaseId().toString());
+    assertThat(
+            responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getQid())
+        .startsWith("01");
+    assertThat(
+            responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getUac())
+        .isNotNull();
+
     assertThat(responseManagementEvent.getEvent().getSource()).isEqualTo("RESPONSE_MANAGEMENT");
     assertThat(responseManagementEvent.getEvent().getChannel()).isEqualTo("RM");
-    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo("RM_UAC_CREATED");
+    assertThat(responseManagementEvent.getEvent().getType()).isEqualTo("FULFILMENT_REQUESTED");
     assertThat(responseManagementEvent.getEvent().getTransactionId()).isNotNull();
     assertThat(responseManagementEvent.getEvent().getDateTime()).isNotNull();
   }
 
   @Test
   @DirtiesContext
-  public void testGetNewIndividualUacQidForCaseDistributesIndividualCaseCreatedEvent()
+  public void testGetNewIndividualUacQidForCaseDistributesFulfilmentEvent()
       throws UnirestException, IOException, InterruptedException {
     // Given
     Case parentCase =
@@ -593,14 +584,20 @@ public class CaseEndpointIT {
     BlockingQueue<String> caseFulfilmentQueue = rabbitQueueHelper.listen(caseFulfilmentsQueueName);
 
     // When
-    Unirest.get(
-            String.format(
-                "http://localhost:%d/cases/%s/qid?individual=true&individualCaseId=%s",
-                port, TEST_CASE_ID_1_EXISTS, individualCaseId.toString()))
-        .header("accept", "application/json")
-        .asJson();
+    HttpResponse<JsonNode> jsonResponse =
+        Unirest.get(
+                String.format(
+                    "http://localhost:%d/cases/%s/qid?individual=true&individualCaseId=%s",
+                    port, TEST_CASE_ID_1_EXISTS, individualCaseId.toString()))
+            .header("accept", "application/json")
+            .asJson();
 
     // Then
+    UacQidDTO actualUacQidDTO =
+        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
+    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("21");
+    assertThat(actualUacQidDTO.getUac()).isNotNull();
+
     String message = rabbitQueueHelper.checkExpectedMessageReceived(caseFulfilmentQueue);
     ResponseManagementEvent responseManagementEvent =
         DataUtils.mapper.readValue(message, ResponseManagementEvent.class);
@@ -611,6 +608,21 @@ public class CaseEndpointIT {
         .isEqualTo(parentCase.getCaseId().toString());
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId())
         .isEqualTo(individualCaseId.toString());
+
+    assertThat(
+            responseManagementEvent
+                .getPayload()
+                .getFulfilmentRequest()
+                .getUacQidCreated()
+                .getCaseId())
+        .isEqualTo(individualCaseId.toString());
+    assertThat(
+            responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getQid())
+        .startsWith("21");
+    assertThat(
+            responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getUac())
+        .isNotNull();
+
     assertThat(responseManagementEvent.getEvent().getSource()).isEqualTo("RESPONSE_MANAGEMENT");
     assertThat(responseManagementEvent.getEvent().getChannel()).isEqualTo("RM");
     assertThat(responseManagementEvent.getEvent().getType()).isEqualTo("FULFILMENT_REQUESTED");

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
@@ -30,6 +30,7 @@ import uk.gov.ons.census.caseapisvc.exception.QidNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.UPRNNotFoundException;
 import uk.gov.ons.census.caseapisvc.exception.UacQidLinkWithNoCaseException;
 import uk.gov.ons.census.caseapisvc.model.dto.ResponseManagementEvent;
+import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 import uk.gov.ons.census.caseapisvc.model.repository.CaseRepository;
@@ -185,12 +186,14 @@ public class CaseServiceTest {
     // Given
     UUID parentCaseId = UUID.randomUUID();
     UUID individualCaseId = UUID.randomUUID();
+    UacQidCreatedPayloadDTO uacQidCreated = new UacQidCreatedPayloadDTO();
 
     // When
     caseService.buildAndSendTelephoneCaptureFulfilmentRequest(
         parentCaseId.toString(),
         RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL,
-        individualCaseId.toString());
+        individualCaseId.toString(),
+        uacQidCreated);
 
     // Then
     ArgumentCaptor<ResponseManagementEvent> eventArgumentCaptor =
@@ -207,5 +210,7 @@ public class CaseServiceTest {
         .isEqualTo(individualCaseId.toString());
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode())
         .isEqualTo("RM_TC_HI");
+    assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated())
+        .isEqualTo(uacQidCreated);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -58,14 +58,26 @@ public class UacQidServiceTest {
   }
 
   @Test
-  public void createAndLinkUacQidSendsRmUacCreatedEvent() {
+  public void createAndLinkUacQidReturnsALovelyObjectWhichIAmVeryFondOf() {
     // Given
     String caseId = UUID.randomUUID().toString();
+    UacQidCreatedPayloadDTO expectedResult = createUacQidCreatedPayload(NEW_QID);
     when(uacQidServiceClient.generateUacQid(eq(TEST_QUESTIONNAIRE_TYPE)))
-        .thenReturn(createUacQidCreatedPayload(NEW_QID));
+        .thenReturn(expectedResult);
 
     // When
-    uacQidService.createAndLinkUacQid(caseId, TEST_QUESTIONNAIRE_TYPE);
+    UacQidCreatedPayloadDTO actualResult =
+        uacQidService.createAndLinkUacQid(caseId, TEST_QUESTIONNAIRE_TYPE);
+
+    assertThat(actualResult).isEqualTo(expectedResult);
+  }
+
+  @Test
+  public void sendUacQidCreatedEventSendsRmUacCreatedEvent() {
+    String caseId = UUID.randomUUID().toString();
+    UacQidCreatedPayloadDTO thingToSend = createUacQidCreatedPayload(NEW_QID, caseId);
+
+    uacQidService.sendUacQidCreatedEvent(thingToSend);
 
     // Then
     ArgumentCaptor<ResponseManagementEvent> uacQidCreatedCaptor =


### PR DESCRIPTION
# Motivation and Context
There was room for minor improvement in the way that we were sending messages which had to be processed in a specific order.

# What has changed
Embedded the new UAC-QID details inside the fulfilment message which gets sent to the Case Processor.

# How to test?
Run the acceptance tests - there should be zero regression (and no errors in the logs anymore!).

# Links
Trello: https://trello.com/c/yNjry5aD