### PR TITLE
RMC-221 CCS case look up by postcode 

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -8,6 +8,7 @@ import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletResponse;
 import ma.glasnost.orika.MapperFacade;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -99,6 +100,18 @@ public final class CaseEndpoint {
     log.debug("Entering findByReference");
 
     return buildCaseContainerDTO(caseService.findByReference(reference), caseEvents);
+  }
+
+  @GetMapping(value = "/ccs/postcode/{postcode}")
+  public List<CaseContainerDTO> findCCSCasesByPostcode(
+      @PathVariable("postcode") String postcode,
+      @RequestParam(value = "caseEvents", required = false, defaultValue = "false")
+          boolean caseEvents) {
+    log.debug("Entering findByPostcode");
+    List<Case> cases = caseService.findCCSCasesByPostcode(postcode);
+    return cases.stream()
+        .map(c -> buildCaseContainerDTO(c, caseEvents))
+        .collect(Collectors.toList());
   }
 
   @GetMapping(value = "/ccs/{caseId}/qid")

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
@@ -16,7 +16,7 @@ public interface CaseRepository extends JpaRepository<Case, UUID> {
   Optional<Case> findByCaseRef(int reference);
 
   @Query(
-      "SELECT c FROM Case c WHERE survey='CCS' AND UPPER(REPLACE(postcode, ' ', '')) LIKE UPPER(REPLACE(:postcode, ' ', ''))")
+      "SELECT c FROM Case c WHERE survey='CCS' AND UPPER(REPLACE(postcode, ' ', '')) = UPPER(REPLACE(:postcode, ' ', ''))")
   List<Case> findCCSCasesByPostcodeIgnoringCaseAndSpaces(@Param("postcode") String postcode);
 
   boolean existsCaseByCaseId(UUID caseId);

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 
 public interface CaseRepository extends JpaRepository<Case, UUID> {
@@ -12,6 +14,10 @@ public interface CaseRepository extends JpaRepository<Case, UUID> {
   Optional<Case> findByCaseId(UUID caseId);
 
   Optional<Case> findByCaseRef(int reference);
+
+  @Query(
+      "SELECT c FROM Case c WHERE survey='CCS' AND UPPER(REPLACE(postcode, ' ', '')) LIKE UPPER(REPLACE(:postcode, ' ', ''))")
+  List<Case> findCCSCasesByPostcodeIgnoringCaseAndSpaces(@Param("postcode") String postcode);
 
   boolean existsCaseByCaseId(UUID caseId);
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -85,6 +85,10 @@ public class CaseService {
     return uacQidLink.getCaze();
   }
 
+  public List<Case> findCCSCasesByPostcode(String postcode) {
+    return caseRepo.findCCSCasesByPostcodeIgnoringCaseAndSpaces(postcode);
+  }
+
   public boolean caseExistsByCaseId(String caseId) {
     UUID caseIdUUID = validateAndConvertCaseIdToUUID(caseId);
     return caseRepo.existsCaseByCaseId(caseIdUUID);

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -20,6 +20,7 @@ import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createMultipleCases
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createSingleCaseWithEvents;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createUacQidCreatedPayload;
 
+import java.util.List;
 import java.util.UUID;
 import ma.glasnost.orika.MapperFacade;
 import ma.glasnost.orika.impl.DefaultMapperFactory;
@@ -428,6 +429,24 @@ public class CaseEndpointUnitTest {
 
     verifyZeroInteractions(caseService);
     verifyZeroInteractions(uacQidService);
+  }
+
+  @Test
+  public void getCCSCasesByPostcode() throws Exception {
+    Case ccsCase = createSingleCaseWithEvents();
+    ccsCase.setSurvey("CCS");
+    ccsCase.setPostcode("AB12BC");
+    when(caseService.findCCSCasesByPostcode(anyString())).thenReturn(List.of(ccsCase));
+
+    mockMvc
+        .perform(
+            get(createUrl("/cases/ccs/postcode/%s", ccsCase.getPostcode()))
+                .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CaseEndpoint.class))
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].id", is(ccsCase.getCaseId().toString())))
+        .andExpect(jsonPath("$[0].postcode", is(ccsCase.getPostcode())));
   }
 
   private String createUrl(String urlFormat, String param1) {


### PR DESCRIPTION
# Motivation and Context
Contact centre needs to be able to search for CCS cases by postcode. 

# What has changed
* Add find CCS cases by postcode endpoint
* Tests for new endpoint

# How to test?
Build and run this image with docker dev. Load some CCS cases, you should be able to hit this endpoint with their postcode and get them back.
Run AT's on the linked branch.

# Links
https://trello.com/c/RxoE4p0V/522-rmc-221-provide-ccs-case-look-up-by-post-code-8
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/168