### PR TITLE
Remove case state

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ If this query parameter is omitted these case events **will not** be returned wi
   "organisationName": "",
   "postcode": "XX1 0XX",
   "region": "E12000009",
-  "state": "ACTIONABLE",
   "surveyType": "CENSUS",
   "townName": "Windleybury",
   "uprn": "10008677190"

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -60,7 +60,5 @@ public class CaseContainerDTO {
 
   private String lad;
 
-  private String state;
-
   private List<CaseEventDTO> caseEvents;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -5,8 +5,6 @@ import java.util.List;
 import java.util.UUID;
 import javax.persistence.Column;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
@@ -94,10 +92,6 @@ public class Case {
 
   @Column(columnDefinition = "timestamp with time zone")
   private OffsetDateTime createdDateTime;
-
-  @Column
-  @Enumerated(EnumType.STRING)
-  private CaseState state;
 
   @OneToMany(mappedBy = "caze")
   List<UacQidLink> uacQidLinks;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/CaseState.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/CaseState.java
@@ -1,5 +1,0 @@
-package uk.gov.ons.census.caseapisvc.model.entity;
-
-public enum CaseState {
-  ACTIONABLE
-}


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can now safely remove the redundant case `state` column from our schemas

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Removed `state` from the repo

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure tests and acceptance tests still pass from the links below

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/dBJe87ZS/481-get-rid-of-casestate-from-case-table-8

https://github.com/ONSdigital/census-rm-case-processor/pull/101
https://github.com/ONSdigital/census-rm-action-scheduler/pull/64
https://github.com/ONSdigital/census-rm-action-worker/pull/9
https://github.com/ONSdigital/census-rm-ddl/pull/32
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/169