### PR TITLE
CE1 Telephone Capture

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
@@ -17,7 +17,19 @@ import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
 public class UacQidService {
 
   private static final Logger log = LoggerFactory.getLogger(UacQidService.class);
-  private final String RM_UAC_CREATED = "RM_UAC_CREATED";
+
+  private static final String RM_UAC_CREATED = "RM_UAC_CREATED";
+
+  private static final String ADDRESS_LEVEL_UNIT = "U";
+  private static final String ADDRESS_LEVEL_ESTAB = "E";
+
+  private static final String COUNTRY_CODE_ENGLAND = "E";
+  private static final String COUNTRY_CODE_WALES = "W";
+  private static final String COUNTRY_CODE_NORTHERN_IRELAND = "N";
+
+  private static final String CASE_TYPE_HOUSEHOLD = "HH";
+  private static final String CASE_TYPE_SPG = "SPG";
+  private static final String CASE_TYPE_CE = "CE";
 
   private RabbitTemplate rabbitTemplate;
   private UacQidServiceClient uacQidServiceClient;
@@ -72,7 +84,9 @@ public class UacQidService {
   public static int calculateQuestionnaireType(
       String treatmentCode, String addressLevel, boolean individual) {
     String country = treatmentCode.substring(treatmentCode.length() - 1);
-    if (!country.equals("E") && !country.equals("W") && !country.equals("N")) {
+    if (!country.equals(COUNTRY_CODE_ENGLAND)
+        && !country.equals(COUNTRY_CODE_WALES)
+        && !country.equals(COUNTRY_CODE_NORTHERN_IRELAND)) {
       throw new IllegalArgumentException(
           String.format("Unknown Country for treatment code %s", treatmentCode));
     }
@@ -82,38 +96,52 @@ public class UacQidService {
         || isIndividualRequestForSPGUnitCase(treatmentCode, addressLevel, individual)
         || isIndividualRequestForCEEstabLevelCaseType(treatmentCode, addressLevel, individual)) {
       switch (country) {
-        case "E":
+        case COUNTRY_CODE_ENGLAND:
           return 21;
-        case "W":
+        case COUNTRY_CODE_WALES:
           return 22;
-        case "N":
+        case COUNTRY_CODE_NORTHERN_IRELAND:
           return 24;
       }
     } else if (isHouseholdCaseType(treatmentCode) || isSpgCaseType(treatmentCode)) {
       switch (country) {
-        case "E":
+        case COUNTRY_CODE_ENGLAND:
           return 1;
-        case "W":
+        case COUNTRY_CODE_WALES:
           return 2;
-        case "N":
+        case COUNTRY_CODE_NORTHERN_IRELAND:
           return 4;
+      }
+    } else if (isCE1RequestForEstabCECase(treatmentCode, addressLevel, individual)) {
+      switch (country) {
+        case COUNTRY_CODE_ENGLAND:
+          return 31;
+        case COUNTRY_CODE_WALES:
+          return 32;
+        case COUNTRY_CODE_NORTHERN_IRELAND:
+          return 34;
       }
     } else {
       throw new IllegalArgumentException(
           String.format(
-              "Unexpected Case Type or Address level for treatment code: '%s', address level: '%s'",
-              treatmentCode, addressLevel));
+              "Unexpected combination of Case Type, Address level and individual request. treatment code: '%s', address level: '%s', individual request: '%s'",
+              treatmentCode, addressLevel, individual));
     }
 
     throw new RuntimeException(
         String.format(
-            "Unprocessable treatment code: '%s' or address level: '%s'",
-            treatmentCode, addressLevel));
+            "Unprocessable combination of Case Type, Address level and individual request. treatment code: '%s', address level: '%s', individual request: '%s'",
+            treatmentCode, addressLevel, individual));
+  }
+
+  private static boolean isCE1RequestForEstabCECase(
+      String treatmentCode, String addressLevel, boolean individual) {
+    return isCeCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_ESTAB) && !individual;
   }
 
   private static boolean isIndividualRequestForSPGUnitCase(
       String treatmentCode, String addressLevel, boolean individual) {
-    return isSpgCaseType(treatmentCode) && addressLevel.equals("U") && individual;
+    return isSpgCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_UNIT) && individual;
   }
 
   private static boolean isIndividualRequestForCEEstabLevelCaseType(
@@ -122,11 +150,15 @@ public class UacQidService {
   }
 
   private static boolean isSpgCaseType(String treatmentCode) {
-    return treatmentCode.startsWith("SPG");
+    return treatmentCode.startsWith(CASE_TYPE_SPG);
   }
 
   private static boolean isHouseholdCaseType(String treatmentCode) {
-    return treatmentCode.startsWith("HH");
+    return treatmentCode.startsWith(CASE_TYPE_HOUSEHOLD);
+  }
+
+  private static boolean isCeCaseType(String treatmentCode) {
+    return treatmentCode.startsWith(CASE_TYPE_CE);
   }
 
   private static boolean isIndividualRequestForHouseholdCaseType(
@@ -135,6 +167,6 @@ public class UacQidService {
   }
 
   private static boolean isUnitLevelCE(String treatmentCode, String addressLevel) {
-    return treatmentCode.startsWith("CE") && addressLevel.equals("U");
+    return isCeCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_UNIT);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -713,6 +713,27 @@ public class CaseEndpointIT {
   }
 
   @Test
+  public void testGetNewCe1UacQidForEnglishCeEstabCase() throws UnirestException, IOException {
+    // Given
+    Case CeEstabCase = getaCase(TEST_CASE_ID_1_EXISTS);
+    CeEstabCase.setTreatmentCode(TEST_CE_ENGLAND_TREATMENT_CODE);
+    CeEstabCase.setAddressLevel("E");
+    CeEstabCase = saveAndRetreiveCase(CeEstabCase);
+
+    // When
+    HttpResponse<JsonNode> jsonResponse =
+        Unirest.get(String.format("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
+            .header("accept", "application/json")
+            .asJson();
+
+    // Then
+    UacQidDTO actualUacQidDTO =
+        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
+    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("31");
+    assertThat(actualUacQidDTO.getUac()).isNotNull();
+  }
+
+  @Test
   public void testFindOneCcsCaseByPostCode() throws IOException, UnirestException {
 
     // Given

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -245,7 +245,7 @@ public class UacQidServiceTest {
   }
 
   @Test
-  public void calculateQuestionnaireTypeForIndividualSPGEUnit() {
+  public void calculateQuestionnaireTypeForIndividualSpgEUnit() {
     // When
     int questionnaireType =
         UacQidService.calculateQuestionnaireType("SPG_XXXXE", ADDRESS_LEVEL_UNIT, true);
@@ -255,7 +255,7 @@ public class UacQidServiceTest {
   }
 
   @Test
-  public void calculateQuestionnaireTypeForIndividualSPGWUnit() {
+  public void calculateQuestionnaireTypeForIndividualSpgWUnit() {
     // When
     int questionnaireType =
         UacQidService.calculateQuestionnaireType("SPG_XXXXW", ADDRESS_LEVEL_UNIT, true);
@@ -265,7 +265,7 @@ public class UacQidServiceTest {
   }
 
   @Test
-  public void calculateQuestionnaireTypeForIndividualSPGNIUnit() {
+  public void calculateQuestionnaireTypeForIndividualSpgNiUnit() {
     // When
     int questionnaireType =
         UacQidService.calculateQuestionnaireType("SPG_XXXXN", ADDRESS_LEVEL_UNIT, true);
@@ -302,6 +302,36 @@ public class UacQidServiceTest {
 
     // Then
     assertThat(questionnaireType).isEqualTo(24);
+  }
+
+  @Test
+  public void calculateQuestionnaireTypeForNonIndividualCeEEstab() {
+    // When
+    int questionnaireType =
+        UacQidService.calculateQuestionnaireType("CE_XXXXE", ADDRESS_LEVEL_ESTABLISHMENT, false);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(31);
+  }
+
+  @Test
+  public void calculateQuestionnaireTypeForNonIndividualCeWEstab() {
+    // When
+    int questionnaireType =
+        UacQidService.calculateQuestionnaireType("CE_XXXXW", ADDRESS_LEVEL_ESTABLISHMENT, false);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(32);
+  }
+
+  @Test
+  public void calculateQuestionnaireTypeForNonIndividualCeNiEstab() {
+    // When
+    int questionnaireType =
+        UacQidService.calculateQuestionnaireType("CE_XXXXN", ADDRESS_LEVEL_ESTABLISHMENT, false);
+
+    // Then
+    assertThat(questionnaireType).isEqualTo(34);
   }
 
   @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
# Motivation and Context
Non individual requests for telephone capture on a CE Estab level case should give back a CE1 QID.

# What has changed
* Add QID mappings for CE1 telephone capture
* Remove "magic" strings from code
* Tests

# How to test?
Build and run the linked AT branch

# Links
https://trello.com/c/2LhJkWc8/549-ce1-telephone-capture-3#
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/175