### PR TITLE
Fix CE Unit individual parameter handling

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -132,22 +132,20 @@ public final class CaseEndpoint {
       @RequestParam(value = "individualCaseId", required = false) String individualCaseId) {
     log.debug("Entering getNewQidByCaseId");
 
-    if (individual) {
-      return handleIndividualQidRequest(caseId, individualCaseId);
-    }
+    if (individualCaseId != null && individual) {
+      return handleNewHiIndividualQidRequest(caseId, individualCaseId);
 
-    if (individualCaseId == null) {
-      return handleQidRequest(caseId, false);
+    } else if (individualCaseId != null) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          "Unexpected Parameter combination, if IndividualCaseId is set, then the individual flag must be true");
     }
-
-    throw new ResponseStatusException(
-        HttpStatus.BAD_REQUEST,
-        "Unexpected Parameter combination, if IndividualCaseId set, then individual flag must be true");
+    return handleQidRequest(caseId, individual);
   }
 
-  private UacQidDTO handleQidRequest(String cazeId, boolean individual) {
+  private UacQidDTO handleQidRequest(String caseId, boolean individual) {
 
-    Case caze = caseService.findByCaseId(cazeId);
+    Case caze = caseService.findByCaseId(caseId);
 
     int questionnaireType =
         calculateQuestionnaireType(caze.getTreatmentCode(), caze.getAddressLevel(), individual);
@@ -164,12 +162,15 @@ public final class CaseEndpoint {
     return uacQidDTO;
   }
 
-  private UacQidDTO handleIndividualQidRequest(String caseId, String individualCaseId) {
+  private UacQidDTO handleNewHiIndividualQidRequest(String caseId, String individualCaseId) {
     Case caze = caseService.findByCaseId(caseId);
 
-    if (caze.getCaseType().equals("SPG") && caze.getAddressLevel().equals("U")
-        || caze.getCaseType().equals("CE") && caze.getAddressLevel().equals("E")) {
-      return handleIndividualQidRequestForSPGUnitLevelCase(caseId, individualCaseId);
+    if (!caze.getCaseType().equals("HH")) {
+      throw new ResponseStatusException(
+          HttpStatus.BAD_REQUEST,
+          String.format(
+              "IndividualCaseId is only valid for case type HH, found case type: %s",
+              caze.getCaseType()));
     }
 
     if (caseService.caseExistsByCaseId(individualCaseId)) {
@@ -194,19 +195,6 @@ public final class CaseEndpoint {
     uacQidDTO.setUac(uacQidCreatedPayload.getUac());
 
     return uacQidDTO;
-  }
-
-  private UacQidDTO handleIndividualQidRequestForSPGUnitLevelCase(
-      String caseId, String individualCaseId) {
-    if (individualCaseId != null) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST,
-          String.format(
-              "SPG Unit level case %s cannot have a new Individual child case added to it",
-              caseId));
-    }
-
-    return handleQidRequest(caseId, true);
   }
 
   @ExceptionHandler({

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
@@ -91,10 +91,10 @@ public class UacQidService {
           String.format("Unknown Country for treatment code %s", treatmentCode));
     }
 
-    if (isUnitLevelCE(treatmentCode, addressLevel)
-        || isIndividualRequestForHouseholdCaseType(treatmentCode, individual)
-        || isIndividualRequestForSPGUnitCase(treatmentCode, addressLevel, individual)
-        || isIndividualRequestForCEEstabLevelCaseType(treatmentCode, addressLevel, individual)) {
+    if (individual
+        && (isCeCaseType(treatmentCode)
+            || isHouseholdCaseType(treatmentCode)
+            || isSpgUnitLevelCase(treatmentCode, addressLevel))) {
       switch (country) {
         case COUNTRY_CODE_ENGLAND:
           return 21;
@@ -112,7 +112,7 @@ public class UacQidService {
         case COUNTRY_CODE_NORTHERN_IRELAND:
           return 4;
       }
-    } else if (isCE1RequestForEstabCECase(treatmentCode, addressLevel, individual)) {
+    } else if (isCE1RequestForEstabCeCase(treatmentCode, addressLevel, individual)) {
       switch (country) {
         case COUNTRY_CODE_ENGLAND:
           return 31;
@@ -134,19 +134,13 @@ public class UacQidService {
             treatmentCode, addressLevel, individual));
   }
 
-  private static boolean isCE1RequestForEstabCECase(
+  private static boolean isCE1RequestForEstabCeCase(
       String treatmentCode, String addressLevel, boolean individual) {
     return isCeCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_ESTAB) && !individual;
   }
 
-  private static boolean isIndividualRequestForSPGUnitCase(
-      String treatmentCode, String addressLevel, boolean individual) {
-    return isSpgCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_UNIT) && individual;
-  }
-
-  private static boolean isIndividualRequestForCEEstabLevelCaseType(
-      String treatmentCode, String addressLevel, boolean individual) {
-    return individual && treatmentCode.startsWith("CE") && addressLevel.equals("E");
+  private static boolean isSpgUnitLevelCase(String treatmentCode, String addressLevel) {
+    return isSpgCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_UNIT);
   }
 
   private static boolean isSpgCaseType(String treatmentCode) {
@@ -159,14 +153,5 @@ public class UacQidService {
 
   private static boolean isCeCaseType(String treatmentCode) {
     return treatmentCode.startsWith(CASE_TYPE_CE);
-  }
-
-  private static boolean isIndividualRequestForHouseholdCaseType(
-      String treatmentCode, boolean individual) {
-    return isHouseholdCaseType(treatmentCode) && individual;
-  }
-
-  private static boolean isUnitLevelCE(String treatmentCode, String addressLevel) {
-    return isCeCaseType(treatmentCode) && addressLevel.equals(ADDRESS_LEVEL_UNIT);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -460,7 +460,10 @@ public class CaseEndpointIT {
 
     // When
     HttpResponse<JsonNode> jsonResponse =
-        Unirest.get(createUrl("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
+        Unirest.get(
+                createUrl(
+                    "http://localhost:%d/cases/%s/qid?individual=true",
+                    port, TEST_CASE_ID_1_EXISTS))
             .header("accept", "application/json")
             .asJson();
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -125,30 +125,30 @@ public class UacQidServiceTest {
   }
 
   @Test
-  public void calculateQuestionnaireTypeForCeEngland() {
+  public void calculateIndividualQuestionnaireTypeForCeUnitEngland() {
     // When
     int questionnaireType =
-        UacQidService.calculateQuestionnaireType("CE_XXXXE", ADDRESS_LEVEL_UNIT);
+        UacQidService.calculateQuestionnaireType("CE_XXXXE", ADDRESS_LEVEL_UNIT, true);
 
     // Then
     assertThat(questionnaireType).isEqualTo(21);
   }
 
   @Test
-  public void calculateQuestionnaireTypeForCeWales() {
+  public void calculateIndividualQuestionnaireTypeForCeUnitWales() {
     // When
     int questionnaireType =
-        UacQidService.calculateQuestionnaireType("CE_XXXXW", ADDRESS_LEVEL_UNIT);
+        UacQidService.calculateQuestionnaireType("CE_XXXXW", ADDRESS_LEVEL_UNIT, true);
 
     // Then
     assertThat(questionnaireType).isEqualTo(22);
   }
 
   @Test
-  public void calculateQuestionnaireTypeForCeNI() {
+  public void calculateIndividualQuestionnaireTypeForCeUnitNI() {
     // When
     int questionnaireType =
-        UacQidService.calculateQuestionnaireType("CE_XXXXN", ADDRESS_LEVEL_UNIT);
+        UacQidService.calculateQuestionnaireType("CE_XXXXN", ADDRESS_LEVEL_UNIT, true);
 
     // Then
     assertThat(questionnaireType).isEqualTo(24);


### PR DESCRIPTION
# Motivation and Context
Since CE Unit telephone capture was first put in the specs of the solution have changed, it should only accept requests with the `individual` flag.

# What has changed
* Only allow CE unit case requests with individual flag
* Refactor endpoint 

# How to test?
Build and run with linked AT branch

# Links
https://trello.com/c/gKgbepbP/548-defect-telephone-capture-ce-unit-api-call-not-as-per-solution-3
https://github.com/ONSdigital/census-rm-acceptance-tests/pull/178