### PR TITLE
Telephone capture bad request errors

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -35,6 +35,7 @@ import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
 import uk.gov.ons.census.caseapisvc.service.CaseService;
 import uk.gov.ons.census.caseapisvc.service.UacQidService;
+import uk.gov.ons.census.caseapisvc.validation.RequestValidator;
 
 @RestController
 @RequestMapping(value = "/cases")
@@ -132,6 +133,9 @@ public final class CaseEndpoint {
       @RequestParam(value = "individualCaseId", required = false) String individualCaseId) {
     log.debug("Entering getNewQidByCaseId");
 
+    Case caze = caseService.findByCaseId(caseId);
+    RequestValidator.validateGetNewQidByCaseIdRequest(caze, individual, individualCaseId);
+
     if (individual) {
       return handleIndividualQidRequest(caseId, individualCaseId);
     }
@@ -141,8 +145,7 @@ public final class CaseEndpoint {
     }
 
     throw new ResponseStatusException(
-        HttpStatus.BAD_REQUEST,
-        "Unexpected Parameter combination, if IndividualCaseId set, then individual flag must be true");
+        HttpStatus.INTERNAL_SERVER_ERROR, "Request validation failed");
   }
 
   private UacQidDTO handleQidRequest(String cazeId, boolean individual) {

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -136,23 +136,14 @@ public final class CaseEndpoint {
     Case caze = caseService.findByCaseId(caseId);
     RequestValidator.validateGetNewQidByCaseIdRequest(caze, individual, individualCaseId);
 
-    if (individual) {
-      return handleIndividualQidRequest(caseId, individualCaseId);
-    }
     if (individualCaseId != null && individual) {
-      return handleNewHiIndividualQidRequest(caseId, individualCaseId);
-
-    } else if (individualCaseId != null) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST,
-          "Unexpected Parameter combination, if IndividualCaseId is set, then the individual flag must be true");
+      return handleNewHiIndividualQidRequest(caze, individualCaseId);
     }
-    return handleQidRequest(caseId, individual);
+
+    return handleQidRequest(caze, individual);
   }
 
-  private UacQidDTO handleQidRequest(String caseId, boolean individual) {
-
-    Case caze = caseService.findByCaseId(caseId);
+  private UacQidDTO handleQidRequest(Case caze, boolean individual) {
 
     int questionnaireType =
         calculateQuestionnaireType(caze.getTreatmentCode(), caze.getAddressLevel(), individual);
@@ -169,17 +160,7 @@ public final class CaseEndpoint {
     return uacQidDTO;
   }
 
-  private UacQidDTO handleNewHiIndividualQidRequest(String caseId, String individualCaseId) {
-    Case caze = caseService.findByCaseId(caseId);
-
-    if (!caze.getCaseType().equals("HH")) {
-      throw new ResponseStatusException(
-          HttpStatus.BAD_REQUEST,
-          String.format(
-              "IndividualCaseId is only valid for case type HH, found case type: %s",
-              caze.getCaseType()));
-    }
-
+  private UacQidDTO handleNewHiIndividualQidRequest(Case caze, String individualCaseId) {
     if (caseService.caseExistsByCaseId(individualCaseId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,

--- a/src/main/java/uk/gov/ons/census/caseapisvc/validation/RequestValidator.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/validation/RequestValidator.java
@@ -1,0 +1,57 @@
+package uk.gov.ons.census.caseapisvc.validation;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.census.caseapisvc.model.entity.Case;
+
+public class RequestValidator {
+  public static void validateGetNewQidByCaseIdRequest(
+      Case caze, boolean individual, String individualCaseId) {
+    if (caze.getCaseType().equals("HH") && individual && individualCaseId == null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("HH") && !individual && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("E")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("E")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("CE")
+        && caze.getAddressLevel().equals("U")
+        && individual
+        && individualCaseId == null) {
+      return; // Valid request
+    } else if (caze.getCaseType().equals("CE") && caze.getAddressLevel().equals("U")) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("E")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("E")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("U")
+        && !individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    } else if (caze.getCaseType().equals("SPG")
+        && caze.getAddressLevel().equals("U")
+        && individual
+        && individualCaseId != null) {
+      throwBadRequest();
+    }
+  }
+
+  private static void throwBadRequest() {
+    throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid request");
+  }
+}

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -456,7 +456,7 @@ public class CaseEndpointIT {
   @Test
   public void testGetNewUacQidForEnglishCeUnitCase() throws UnirestException, IOException {
     // Given
-    setupUnitTestCaseWithTreatmentCode(TEST_CASE_ID_1_EXISTS, TEST_CE_ENGLAND_TREATMENT_CODE);
+    setupCEUnitTestCaseWithTreatmentCode(TEST_CASE_ID_1_EXISTS, TEST_CE_ENGLAND_TREATMENT_CODE);
 
     // When
     HttpResponse<JsonNode> jsonResponse =
@@ -963,6 +963,15 @@ public class CaseEndpointIT {
   private Case setupUnitTestCaseWithTreatmentCode(String caseId, String treatmentCode) {
     Case caze = getaCase(caseId);
     caze.setCaseType("HH");
+    caze.setTreatmentCode(treatmentCode);
+    caze.setAddressLevel("U");
+
+    return saveAndRetreiveCase(caze);
+  }
+
+  private Case setupCEUnitTestCaseWithTreatmentCode(String caseId, String treatmentCode) {
+    Case caze = getaCase(caseId);
+    caze.setCaseType("CE");
     caze.setTreatmentCode(treatmentCode);
     caze.setAddressLevel("U");
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -421,6 +421,7 @@ public class CaseEndpointUnitTest {
   @Test
   public void getNewIndividualUacQidButIndividualParamNotGiven() throws Exception {
     Case parentCase = createSingleCaseWithEvents();
+    when(caseService.findByCaseId(anyString())).thenReturn(parentCase);
     String individualCaseId = UUID.randomUUID().toString();
 
     mockMvc

--- a/src/test/java/uk/gov/ons/census/caseapisvc/validation/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/validation/RequestValidatorTest.java
@@ -1,0 +1,71 @@
+package uk.gov.ons.census.caseapisvc.validation;
+
+import static org.junit.Assert.fail;
+
+import java.util.UUID;
+import org.junit.Test;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.census.caseapisvc.model.entity.Case;
+
+public class RequestValidatorTest {
+  @Test
+  public void testAllTheValidGetNewQidByCaseIdRequests() {
+    testValidGetNewQidByCaseIdCombination("HH", "U", false, null);
+    testValidGetNewQidByCaseIdCombination("HH", "U", true, "test_case_id");
+
+    testValidGetNewQidByCaseIdCombination("CE", "E", false, null);
+    testValidGetNewQidByCaseIdCombination("CE", "E", true, null);
+
+    testValidGetNewQidByCaseIdCombination("CE", "U", true, null);
+
+    testValidGetNewQidByCaseIdCombination("SPG", "E", false, null);
+    testValidGetNewQidByCaseIdCombination("SPG", "E", true, null);
+
+    testValidGetNewQidByCaseIdCombination("SPG", "U", false, null);
+    testValidGetNewQidByCaseIdCombination("SPG", "U", true, null);
+  }
+
+  @Test
+  public void testAllTheInvalidGetNewQidByCaseIdRequests() {
+    testInvalidGetNewQidByCaseIdCombination("HH", "U", true, null);
+    testInvalidGetNewQidByCaseIdCombination("HH", "U", false, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("CE", "E", false, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("CE", "E", true, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("CE", "U", false, null);
+    testInvalidGetNewQidByCaseIdCombination("CE", "U", false, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("CE", "U", true, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("SPG", "E", false, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("SPG", "E", true, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("SPG", "U", false, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("SPG", "U", true, "test_case_id");
+  }
+
+  private void testValidGetNewQidByCaseIdCombination(
+      String caseType, String addressLevel, boolean individual, String individualCaseId) {
+    UUID caseId = UUID.randomUUID();
+    Case caze = new Case();
+    caze.setCaseId(caseId);
+    caze.setCaseType(caseType);
+    caze.setAddressLevel(addressLevel);
+
+    RequestValidator.validateGetNewQidByCaseIdRequest(caze, individual, individualCaseId);
+  }
+
+  private void testInvalidGetNewQidByCaseIdCombination(
+      String caseType, String addressLevel, boolean individual, String individualCaseId) {
+    UUID caseId = UUID.randomUUID();
+    Case caze = new Case();
+    caze.setCaseId(caseId);
+    caze.setCaseType(caseType);
+    caze.setAddressLevel(addressLevel);
+
+    try {
+      RequestValidator.validateGetNewQidByCaseIdRequest(caze, individual, individualCaseId);
+    } catch (ResponseStatusException responseStatusException) {
+      // It worked
+      return;
+    }
+
+    fail("Invalid request was not detected");
+  }
+}


### PR DESCRIPTION
# Motivation and Context
There are a large number (20) of valid and invalid combinations when making a request for a new UAC-QID pair, using the Case API. We need to make sure that we reject the bad requests.

# What has changed
Introduced a 'request validity' checker with business rules per confluence document attached to Trello ticket.

# How to test?
Run the ATs and check for zero regression. Try manually calling the Case API with invalid requests.

# Links
Trello: https://trello.com/c/goE4Sl9C