### PR TITLE
add formtype and questionnairetype to caseapi

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -28,8 +28,8 @@ import uk.gov.ons.census.caseapisvc.exception.UPRNNotFoundException;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseEventDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.QidDTO;
+import uk.gov.ons.census.caseapisvc.model.dto.TelephoneCaptureDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
-import uk.gov.ons.census.caseapisvc.model.dto.UacQidDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.UacQidLink;
@@ -43,6 +43,9 @@ public final class CaseEndpoint {
   private static final Logger log = LoggerFactory.getLogger(CaseEndpoint.class);
   private static final String RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL = "RM_TC_HI";
   private static final String RM_TELEPHONE_CAPTURE = "RM_TC";
+  private static final String HH_FORM_TYPE = "H";
+  private static final String IND_FORM_TYPE = "I";
+  private static final String CE1_FORM_TYPE = "C";
 
   private final CaseService caseService;
   private final MapperFacade mapperFacade;
@@ -126,7 +129,7 @@ public final class CaseEndpoint {
   }
 
   @GetMapping(value = "/{caseId}/qid")
-  public UacQidDTO getNewQidByCaseId(
+  public TelephoneCaptureDTO getNewQidByCaseId(
       @PathVariable("caseId") String caseId,
       @RequestParam(value = "individual", required = false, defaultValue = "false")
           boolean individual,
@@ -143,7 +146,7 @@ public final class CaseEndpoint {
     return handleQidRequest(caze, individual);
   }
 
-  private UacQidDTO handleQidRequest(Case caze, boolean individual) {
+  private TelephoneCaptureDTO handleQidRequest(Case caze, boolean individual) {
 
     int questionnaireType =
         calculateQuestionnaireType(caze.getTreatmentCode(), caze.getAddressLevel(), individual);
@@ -153,14 +156,11 @@ public final class CaseEndpoint {
 
     caseService.buildAndSendTelephoneCaptureFulfilmentRequest(
         caze.getCaseId().toString(), RM_TELEPHONE_CAPTURE, null, uacQidCreatedPayload);
-    UacQidDTO uacQidDTO = new UacQidDTO();
-    uacQidDTO.setQuestionnaireId(uacQidCreatedPayload.getQid());
-    uacQidDTO.setUac(uacQidCreatedPayload.getUac());
 
-    return uacQidDTO;
+    return buildTelephoneCaptureDTO(uacQidCreatedPayload, questionnaireType);
   }
 
-  private UacQidDTO handleNewHiIndividualQidRequest(Case caze, String individualCaseId) {
+  private TelephoneCaptureDTO handleNewHiIndividualQidRequest(Case caze, String individualCaseId) {
     if (caseService.caseExistsByCaseId(individualCaseId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,
@@ -178,11 +178,8 @@ public final class CaseEndpoint {
         RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL,
         individualCaseId,
         uacQidCreatedPayload);
-    UacQidDTO uacQidDTO = new UacQidDTO();
-    uacQidDTO.setQuestionnaireId(uacQidCreatedPayload.getQid());
-    uacQidDTO.setUac(uacQidCreatedPayload.getUac());
 
-    return uacQidDTO;
+    return buildTelephoneCaptureDTO(uacQidCreatedPayload, questionnaireType);
   }
 
   @ExceptionHandler({
@@ -223,5 +220,35 @@ public final class CaseEndpoint {
     caseContainerDTO.setCaseEvents(caseEvents);
 
     return caseContainerDTO;
+  }
+
+  private TelephoneCaptureDTO buildTelephoneCaptureDTO(
+      UacQidCreatedPayloadDTO uacQidCreatedPayload, int questionnaireType) {
+    TelephoneCaptureDTO telephoneCaptureDTO = new TelephoneCaptureDTO();
+    telephoneCaptureDTO.setQuestionnaireId(uacQidCreatedPayload.getQid());
+    telephoneCaptureDTO.setUac(uacQidCreatedPayload.getUac());
+    telephoneCaptureDTO.setFormType(mapQuestionnaireTypeToFormType(questionnaireType));
+    telephoneCaptureDTO.setQuestionnaireType(String.format("%02d", questionnaireType));
+    return telephoneCaptureDTO;
+  }
+
+  private String mapQuestionnaireTypeToFormType(int questionnaireType) {
+    switch (questionnaireType) {
+      case 1:
+      case 2:
+      case 4:
+        return HH_FORM_TYPE;
+      case 21:
+      case 22:
+      case 24:
+        return IND_FORM_TYPE;
+      case 31:
+      case 32:
+      case 34:
+        return CE1_FORM_TYPE;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Invalid QuestionnaireType: '%d'", questionnaireType));
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -129,7 +129,7 @@ public final class CaseEndpoint {
   }
 
   @GetMapping(value = "/{caseId}/qid")
-  public TelephoneCaptureDTO getNewQidByCaseId(
+  public TelephoneCaptureDTO getNewQidForTelephoneCapture(
       @PathVariable("caseId") String caseId,
       @RequestParam(value = "individual", required = false, defaultValue = "false")
           boolean individual,
@@ -140,13 +140,13 @@ public final class CaseEndpoint {
     RequestValidator.validateGetNewQidByCaseIdRequest(caze, individual, individualCaseId);
 
     if (individualCaseId != null && individual) {
-      return handleNewHiIndividualQidRequest(caze, individualCaseId);
+      return handleNewIndividualTelephoneCaptureRequest(caze, individualCaseId);
     }
 
-    return handleQidRequest(caze, individual);
+    return handleTelephoneCaptureRequest(caze, individual);
   }
 
-  private TelephoneCaptureDTO handleQidRequest(Case caze, boolean individual) {
+  private TelephoneCaptureDTO handleTelephoneCaptureRequest(Case caze, boolean individual) {
 
     int questionnaireType =
         calculateQuestionnaireType(caze.getTreatmentCode(), caze.getAddressLevel(), individual);
@@ -160,7 +160,8 @@ public final class CaseEndpoint {
     return buildTelephoneCaptureDTO(uacQidCreatedPayload, questionnaireType);
   }
 
-  private TelephoneCaptureDTO handleNewHiIndividualQidRequest(Case caze, String individualCaseId) {
+  private TelephoneCaptureDTO handleNewIndividualTelephoneCaptureRequest(
+      Case caze, String individualCaseId) {
     if (caseService.caseExistsByCaseId(individualCaseId)) {
       throw new ResponseStatusException(
           HttpStatus.BAD_REQUEST,

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/TelephoneCaptureDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/TelephoneCaptureDTO.java
@@ -3,7 +3,9 @@ package uk.gov.ons.census.caseapisvc.model.dto;
 import lombok.Data;
 
 @Data
-public class UacQidDTO {
+public class TelephoneCaptureDTO {
   private String questionnaireId;
   private String uac;
+  private String formType;
+  private String questionnaireType;
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -35,7 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import uk.gov.ons.census.caseapisvc.model.dto.CaseContainerDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.QidDTO;
 import uk.gov.ons.census.caseapisvc.model.dto.ResponseManagementEvent;
-import uk.gov.ons.census.caseapisvc.model.dto.UacQidDTO;
+import uk.gov.ons.census.caseapisvc.model.dto.TelephoneCaptureDTO;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 import uk.gov.ons.census.caseapisvc.model.entity.Event;
 import uk.gov.ons.census.caseapisvc.model.entity.EventType;
@@ -447,14 +447,18 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("01");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("01");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
+    assertThat(actualTelephoneCaptureDTO.getFormType()).isEqualTo("H");
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireType()).isEqualTo("01");
   }
 
   @Test
-  public void testGetNewUacQidForEnglishCeUnitCase() throws UnirestException, IOException {
+  public void testGetNewIndividualUacQidForEnglishCeUnitCase()
+      throws UnirestException, IOException {
     // Given
     setupCEUnitTestCaseWithTreatmentCode(TEST_CASE_ID_1_EXISTS, TEST_CE_ENGLAND_TREATMENT_CODE);
 
@@ -468,10 +472,13 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("21");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("21");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
+    assertThat(actualTelephoneCaptureDTO.getFormType()).isEqualTo("I");
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireType()).isEqualTo("21");
   }
 
   @Test
@@ -486,22 +493,22 @@ public class CaseEndpointIT {
         Unirest.get(createUrl("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
             .header("accept", "application/json")
             .asJson();
-    UacQidDTO firstUacQidDTO =
+    TelephoneCaptureDTO firstTelephoneCaptureDTO =
         DataUtils.mapper.readValue(
-            firstJsonResponse.getBody().getObject().toString(), UacQidDTO.class);
+            firstJsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
 
     HttpResponse<JsonNode> secondJsonResponse =
         Unirest.get(createUrl("http://localhost:%d/cases/%s/qid", port, TEST_CASE_ID_1_EXISTS))
             .header("accept", "application/json")
             .asJson();
-    UacQidDTO secondUacQidDTO =
+    TelephoneCaptureDTO secondTelephoneCaptureDTO =
         DataUtils.mapper.readValue(
-            secondJsonResponse.getBody().getObject().toString(), UacQidDTO.class);
+            secondJsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
 
     // Then
-    assertThat(firstUacQidDTO.getQuestionnaireId())
-        .isNotEqualTo(secondUacQidDTO.getQuestionnaireId());
-    assertThat(firstUacQidDTO.getUac()).isNotEqualTo(secondUacQidDTO.getUac());
+    assertThat(firstTelephoneCaptureDTO.getQuestionnaireId())
+        .isNotEqualTo(secondTelephoneCaptureDTO.getQuestionnaireId());
+    assertThat(firstTelephoneCaptureDTO.getUac()).isNotEqualTo(secondTelephoneCaptureDTO.getUac());
   }
 
   @Test
@@ -522,10 +529,13 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("21");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("21");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
+    assertThat(actualTelephoneCaptureDTO.getFormType()).isEqualTo("I");
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireType()).isEqualTo("21");
   }
 
   @Test
@@ -545,10 +555,11 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("01");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("01");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
 
     String message = rabbitQueueHelper.checkExpectedMessageReceived(caseFulfilmentQueue);
     ResponseManagementEvent responseManagementEvent =
@@ -603,10 +614,11 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("21");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("21");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
 
     String message = rabbitQueueHelper.checkExpectedMessageReceived(caseFulfilmentQueue);
     ResponseManagementEvent responseManagementEvent =
@@ -678,10 +690,11 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("21");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("21");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
 
     String message = rabbitQueueHelper.checkExpectedMessageReceived(caseFulfilmentQueue);
     ResponseManagementEvent responseManagementEvent =
@@ -730,10 +743,13 @@ public class CaseEndpointIT {
             .asJson();
 
     // Then
-    UacQidDTO actualUacQidDTO =
-        DataUtils.mapper.readValue(jsonResponse.getBody().getObject().toString(), UacQidDTO.class);
-    assertThat(actualUacQidDTO.getQuestionnaireId()).startsWith("31");
-    assertThat(actualUacQidDTO.getUac()).isNotNull();
+    TelephoneCaptureDTO actualTelephoneCaptureDTO =
+        DataUtils.mapper.readValue(
+            jsonResponse.getBody().getObject().toString(), TelephoneCaptureDTO.class);
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireId()).startsWith("31");
+    assertThat(actualTelephoneCaptureDTO.getUac()).isNotNull();
+    assertThat(actualTelephoneCaptureDTO.getFormType()).isEqualTo("C");
+    assertThat(actualTelephoneCaptureDTO.getQuestionnaireType()).isEqualTo("31");
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -350,7 +350,9 @@ public class CaseEndpointUnitTest {
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$.questionnaireId", is(TEST_QID)))
-        .andExpect(jsonPath("$.uac", is(CREATED_UAC)));
+        .andExpect(jsonPath("$.uac", is(CREATED_UAC)))
+        .andExpect(jsonPath("$.formType", is("H")))
+        .andExpect(jsonPath("$.questionnaireType", is("01")));
 
     verify(uacQidService).createAndLinkUacQid(eq(caze.getCaseId().toString()), anyInt());
     verify(caseService)
@@ -386,7 +388,9 @@ public class CaseEndpointUnitTest {
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$.questionnaireId", is(TEST_QID)))
-        .andExpect(jsonPath("$.uac", is(CREATED_UAC)));
+        .andExpect(jsonPath("$.uac", is(CREATED_UAC)))
+        .andExpect(jsonPath("$.formType", is("I")))
+        .andExpect(jsonPath("$.questionnaireType", is("21")));
 
     verify(caseService)
         .buildAndSendTelephoneCaptureFulfilmentRequest(
@@ -476,7 +480,9 @@ public class CaseEndpointUnitTest {
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$.questionnaireId", is(TEST_QID)))
-        .andExpect(jsonPath("$.uac", is(CREATED_UAC)));
+        .andExpect(jsonPath("$.uac", is(CREATED_UAC)))
+        .andExpect(jsonPath("$.formType", is("I")))
+        .andExpect(jsonPath("$.questionnaireType", is("21")));
 
     verify(caseService, never()).caseExistsByCaseId(caze.getCaseId().toString());
   }
@@ -500,7 +506,9 @@ public class CaseEndpointUnitTest {
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$.questionnaireId", is(TEST_QID)))
-        .andExpect(jsonPath("$.uac", is(CREATED_UAC)));
+        .andExpect(jsonPath("$.uac", is(CREATED_UAC)))
+        .andExpect(jsonPath("$.formType", is("I")))
+        .andExpect(jsonPath("$.questionnaireType", is("21")));
 
     verify(caseService, never()).caseExistsByCaseId(caze.getCaseId().toString());
   }
@@ -524,7 +532,9 @@ public class CaseEndpointUnitTest {
         .andExpect(status().isOk())
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$.questionnaireId", is(TEST_QID)))
-        .andExpect(jsonPath("$.uac", is(CREATED_UAC)));
+        .andExpect(jsonPath("$.uac", is(CREATED_UAC)))
+        .andExpect(jsonPath("$.formType", is("I")))
+        .andExpect(jsonPath("$.questionnaireType", is("21")));
 
     verify(caseService, never()).caseExistsByCaseId(caze.getCaseId().toString());
   }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
we need to return formType and questionnaire type in the the qid telephone capture endpoints on the case-api

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
New Fields for the telephone capture endpoint.
"formType":"",
"questionnaireType":""
Options for form type are:
I (individual)
H (household)
C (CE1)
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Maven clean install - run with acceptance tests on branch with the [same name](https://github.com/ONSdigital/census-rm-acceptance-tests/pull/183).
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/kCViPjQB/523-add-formtype-and-questionnaire-type-to-case-api-5
# Screenshots (if appropriate):