### PR TITLE
addressType and caseType confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If this query parameter is omitted these case events **will not** be returned wi
   "arid": "DDR190314000000195677",
   "caseEvents": [],
   "caseRef": "31283399",
-  "caseType": "HH",
+  "addressType": "HH",
   "collectionExerciseId": "77c26716-5936-43e8-b56b-f5ca71765603",
   "createdDateTime": "2019-10-25T08:34:34.680556Z",
   "estabArid": "DDR190314000000113742",

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -25,7 +25,7 @@ public class CaseContainerDTO {
 
   private String surveyType;
 
-  @JsonProperty("caseType")
+  @JsonProperty("addressType")
   private String addressType;
 
   private OffsetDateTime createdDateTime;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -25,7 +25,6 @@ public class CaseContainerDTO {
 
   private String surveyType;
 
-  @JsonProperty("addressType")
   private String addressType;
 
   private OffsetDateTime createdDateTime;


### PR DESCRIPTION
# Motivation and Context
Case in case-api now has both caseType and addressType but we call the addressType "caseType" in the JSON messages we return so it can be confusing

# What has changed
Now when JSON is returned, caseType is called addressType

# How to test?
Clone, build and run IT and unit tests
Get case ref from DB and check that the JSON from likes of Case Ref (http://localhost:8161/cases/ref/{reference) returns addressType instead of caseType

# Links
https://trello.com/c/FlnWxlG2
https://collaborate2.ons.gov.uk/confluence/display/CATD/Case+API

