### PR TITLE
add caseType field back into the case lookup endpoints

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -27,6 +27,8 @@ public class CaseContainerDTO {
 
   private String addressType;
 
+  private String caseType;
+
   private OffsetDateTime createdDateTime;
 
   private String addressLine1;


### PR DESCRIPTION
# Motivation and Context
The caseType field was mistakenly removed and needs to be re-instated as its a mandatory field

# What has changed
caseType is now being returned in the case lookups endpoints

# How to test?
- load a sample
- do a case lookup api request and you should see the caseType field being returned

# Links
https://trello.com/c/c6oPcrxF/690-case-api