### PR TITLE
Add missing indexes to improve performance

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Event.java
@@ -25,8 +25,10 @@ import org.hibernate.annotations.TypeDefs;
 @Entity
 @Table(
     indexes = {
-      @Index(name = "event_type_idx", columnList = "event_type"),
-      @Index(name = "rm_event_processed_idx", columnList = "rm_event_processed")
+        @Index(name = "event_type_idx", columnList = "event_type"),
+        @Index(name = "rm_event_processed_idx", columnList = "rm_event_processed"),
+        @Index(name = "event_uac_qid_link_id", columnList = "uac_qid_link_id"),
+        @Index(name = "event_caze_case_id", columnList = "caze_case_id")
     })
 public class Event {
   @Id private UUID id;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Event.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Event.java
@@ -25,10 +25,10 @@ import org.hibernate.annotations.TypeDefs;
 @Entity
 @Table(
     indexes = {
-        @Index(name = "event_type_idx", columnList = "event_type"),
-        @Index(name = "rm_event_processed_idx", columnList = "rm_event_processed"),
-        @Index(name = "event_uac_qid_link_id", columnList = "uac_qid_link_id"),
-        @Index(name = "event_caze_case_id", columnList = "caze_case_id")
+      @Index(name = "event_type_idx", columnList = "event_type"),
+      @Index(name = "rm_event_processed_idx", columnList = "rm_event_processed"),
+      @Index(name = "event_uac_qid_link_id", columnList = "uac_qid_link_id"),
+      @Index(name = "event_caze_case_id", columnList = "caze_case_id")
     })
 public class Event {
   @Id private UUID id;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/UacQidLink.java
@@ -20,7 +20,11 @@ import org.hibernate.annotations.UpdateTimestamp;
 @ToString(onlyExplicitlyIncluded = true)
 @Data
 @Entity
-@Table(indexes = {@Index(name = "qid_idx", columnList = "qid")})
+@Table(
+    indexes = {
+        @Index(name = "qid_idx", columnList = "qid"),
+        @Index(name = "uac_qid_caze_case_id", columnList = "caze_case_id")
+    })
 public class UacQidLink {
   @Id private UUID id;
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/UacQidLink.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/UacQidLink.java
@@ -22,8 +22,8 @@ import org.hibernate.annotations.UpdateTimestamp;
 @Entity
 @Table(
     indexes = {
-        @Index(name = "qid_idx", columnList = "qid"),
-        @Index(name = "uac_qid_caze_case_id", columnList = "caze_case_id")
+      @Index(name = "qid_idx", columnList = "qid"),
+      @Index(name = "uac_qid_caze_case_id", columnList = "caze_case_id")
     })
 public class UacQidLink {
   @Id private UUID id;


### PR DESCRIPTION
# Motivation and Context
Case API was performing very badly when retrieving case events.

# What has changed
Added indexes to both `uac_qid_link` and `event` table to prevent table-scanning.

# How to test?
Load large sample. Call case API including `?caseEvents=true`. It should be fast response time.

# Links
Trello: https://trello.com/c/fHPtdl59