### PR TITLE
Add Prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
       <artifactId>hibernate-types-5</artifactId>
       <version>2.4.4</version>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+    </dependency>
 
     <!--    Test Dependencies below this point -->
     <dependency>

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -5,6 +5,7 @@ import static uk.gov.ons.census.caseapisvc.service.UacQidService.calculateQuesti
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import io.micrometer.core.annotation.Timed;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
@@ -39,6 +40,7 @@ import uk.gov.ons.census.caseapisvc.validation.RequestValidator;
 
 @RestController
 @RequestMapping(value = "/cases")
+@Timed
 public final class CaseEndpoint {
   private static final Logger log = LoggerFactory.getLogger(CaseEndpoint.class);
   private static final String RM_TELEPHONE_CAPTURE_HOUSEHOLD_INDIVIDUAL = "RM_TC_HI";

--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/UacQidEndpoint.java
@@ -2,6 +2,7 @@ package uk.gov.ons.census.caseapisvc.endpoint;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import io.micrometer.core.annotation.Timed;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,6 +15,7 @@ import uk.gov.ons.census.caseapisvc.service.UacQidService;
 
 @RestController
 @RequestMapping(value = "/uacqid")
+@Timed
 public class UacQidEndpoint {
 
   private static final Logger log = LoggerFactory.getLogger(UacQidEndpoint.class);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,9 +38,16 @@ logging:
 
 management:
   endpoints:
-    enabled-by-default: true
+    enabled-by-default: false
+    web:
+      exposure:
+        include: info, health, prometheus
   endpoint:
     info:
+      enabled: true
+    health:
+      enabled: true
+    prometheus:
       enabled: true
 
 uacservice:


### PR DESCRIPTION
# Motivation and Context
We need metrics to ensure that the Case API is responding in line with our NFRs and to spot errors etc.

# What has changed
Added Prometheus scrapeable metrics using Micrometer, which is auto-wired into Spring Boot. Added `@Timing` to the API endpoints.

# How to test?
Go to `http://<case API URL>/actuator/prometheus` to view the metrics.

# Links
Trello: https://trello.com/c/98bq2JmZ