### PR TITLE
Split DTO and Entity packages again

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/RefusalTypeDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/RefusalTypeDTO.java
@@ -1,0 +1,6 @@
+package uk.gov.ons.census.caseapisvc.model.dto;
+
+public enum RefusalTypeDTO {
+  HARD_REFUSAL,
+  EXTRAORDINARY_REFUSAL
+}

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.TypeDefs;
 import org.hibernate.annotations.UpdateTimestamp;
-import uk.gov.ons.census.caseapisvc.model.dto.RefusalType;
 
 // The bidirectional relationships with other entities can cause stack overflows with the default
 // toString

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/RefusalType.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/RefusalType.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.caseapisvc.model.dto;
+package uk.gov.ons.census.caseapisvc.model.entity;
 
 public enum RefusalType {
   HARD_REFUSAL,


### PR DESCRIPTION
# Motivation and Context
We can't use DTO classes in the entity package, and we shouldn't use entity classes in the DTO package. Each package has its own specific requirements. DTOs are for moving data across APIs/Rabbit. Entities are for persisting data in the DB. Never the twain shall meet.

The DDL auto-generation script was broken with the following error:
```
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] /Users/Nick/dev/java/census-rm-ddl/git_cloned_src/uk/gov/ons/census/casesvc/model/entity/Case.java:[14,43] package uk.gov.ons.census.casesvc.model.dto does not exist
[ERROR] /Users/Nick/dev/java/census-rm-ddl/git_cloned_src/uk/gov/ons/census/casesvc/model/entity/Case.java:[19,1] cannot find symbol
  symbol:   class RefusalType
  location: class uk.gov.ons.census.casesvc.model.entity.Case
[INFO] 2 errors
```

This begs the question, why is the process of auto-generating the DDL not being followed?

# What has changed
Created a `RefusalType` in the entity package. Renamed the one in the dto package to be `RefusalTypeDTO`.

# How to test?
Zero regression.

# Links
Trello: 