### PR TITLE
Use UUId type for UUID data

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/exception/CaseIdInvalidException.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/exception/CaseIdInvalidException.java
@@ -1,7 +1,0 @@
-package uk.gov.ons.census.caseapisvc.exception;
-
-public class CaseIdInvalidException extends RuntimeException {
-  public CaseIdInvalidException(String caseId) {
-    super(String.format("Case Id '%s' is invalid", caseId));
-  }
-}

--- a/src/main/java/uk/gov/ons/census/caseapisvc/exception/CaseIdNotFoundException.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/exception/CaseIdNotFoundException.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.census.caseapisvc.exception;
 
+import java.util.UUID;
+
 public class CaseIdNotFoundException extends RuntimeException {
-  public CaseIdNotFoundException(String caseId) {
-    super(String.format("Case Id '%s' not found", caseId));
+  public CaseIdNotFoundException(UUID caseId) {
+    super(String.format("Case Id '%s' not found", caseId.toString()));
   }
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseContainerDTO.java
@@ -3,6 +3,7 @@ package uk.gov.ons.census.caseapisvc.model.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -10,7 +11,7 @@ public class CaseContainerDTO {
   private String caseRef;
 
   @JsonProperty("id")
-  private String caseId;
+  private UUID caseId;
 
   private String estabType;
 
@@ -18,7 +19,7 @@ public class CaseContainerDTO {
 
   private String estabUprn;
 
-  private String collectionExerciseId;
+  private UUID collectionExerciseId;
 
   private String surveyType;
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseEventDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseEventDTO.java
@@ -2,12 +2,13 @@ package uk.gov.ons.census.caseapisvc.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class CaseEventDTO {
 
-  private String id;
+  private UUID id;
 
   private String eventType;
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/EventDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/EventDTO.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.census.caseapisvc.model.dto;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
@@ -9,5 +10,5 @@ public class EventDTO {
   private String source = "RESPONSE_MANAGEMENT";
   private String channel = "RM";
   private OffsetDateTime dateTime;
-  private String transactionId;
+  private UUID transactionId;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/FulfilmentRequestDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/FulfilmentRequestDTO.java
@@ -2,18 +2,19 @@ package uk.gov.ons.census.caseapisvc.model.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class FulfilmentRequestDTO {
 
   @JsonInclude(Include.NON_NULL)
-  private String caseId;
+  private UUID caseId;
 
   private String fulfilmentCode;
 
   @JsonInclude(Include.NON_NULL)
-  private String individualCaseId;
+  private UUID individualCaseId;
 
   private UacQidCreatedPayloadDTO uacQidCreated;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/UacQidCreatedPayloadDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/UacQidCreatedPayloadDTO.java
@@ -1,10 +1,11 @@
 package uk.gov.ons.census.caseapisvc.model.dto;
 
+import java.util.UUID;
 import lombok.Data;
 
 @Data
 public class UacQidCreatedPayloadDTO {
   private String uac;
   private String qid;
-  private String caseId;
+  private UUID caseId;
 }

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -94,9 +94,9 @@ public class Case {
 
   @Column private Integer ceActualResponses;
 
-  @Column private String collectionExerciseId;
+  @Column private UUID collectionExerciseId;
 
-  @Column private String actionPlanId;
+  @Column private UUID actionPlanId;
 
   @Column(nullable = false)
   private String survey;

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/UacQidService.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.census.caseapisvc.service;
 
+import java.util.UUID;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.census.caseapisvc.client.UacQidServiceClient;
 import uk.gov.ons.census.caseapisvc.model.dto.UacQidCreatedPayloadDTO;
@@ -22,7 +23,7 @@ public class UacQidService {
     this.uacQidServiceClient = uacQidServiceClient;
   }
 
-  public UacQidCreatedPayloadDTO createAndLinkUacQid(String caseId, int questionnaireType) {
+  public UacQidCreatedPayloadDTO createAndLinkUacQid(UUID caseId, int questionnaireType) {
     UacQidCreatedPayloadDTO uacQidCreatedPayload =
         uacQidServiceClient.generateUacQid(questionnaireType);
     uacQidCreatedPayload.setCaseId(caseId);

--- a/src/main/java/uk/gov/ons/census/caseapisvc/validation/RequestValidator.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/validation/RequestValidator.java
@@ -1,12 +1,13 @@
 package uk.gov.ons.census.caseapisvc.validation;
 
+import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.census.caseapisvc.model.entity.Case;
 
 public class RequestValidator {
   public static void validateGetNewQidByCaseIdRequest(
-      Case caze, boolean individual, String individualCaseId) {
+      Case caze, boolean individual, UUID individualCaseId) {
     if (caze.getCaseType().equals("HH") && individual && individualCaseId == null) {
       throwBadRequest();
     } else if (caze.getCaseType().equals("HH") && !individual && individualCaseId != null) {

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -256,7 +256,7 @@ public class CaseEndpointIT {
 
     CaseContainerDTO actualData = extractCaseContainerDTOFromResponse(response);
 
-    assertThat(actualData.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(actualData.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(actualData.getCaseEvents().size()).isEqualTo(1);
     assertThat(actualData.getSecureEstablishment()).isNull();
   }
@@ -275,7 +275,7 @@ public class CaseEndpointIT {
 
     CaseContainerDTO actualData = extractCaseContainerDTOFromResponse(response);
 
-    assertThat(actualData.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(actualData.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(actualData.getCaseEvents().size()).isEqualTo(0);
     assertThat(actualData.getSecureEstablishment()).isNull();
   }
@@ -293,7 +293,7 @@ public class CaseEndpointIT {
 
     CaseContainerDTO actualData = extractCaseContainerDTOFromResponse(response);
 
-    assertThat(actualData.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(actualData.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(actualData.getCaseEvents().size()).isEqualTo(0);
   }
 
@@ -314,7 +314,7 @@ public class CaseEndpointIT {
             .header("accept", "application/json")
             .asJson();
 
-    assertThat(jsonResponse.getStatus()).isEqualTo(NOT_FOUND.value());
+    assertThat(jsonResponse.getStatus()).isEqualTo(BAD_REQUEST.value());
   }
 
   @Test
@@ -396,7 +396,7 @@ public class CaseEndpointIT {
             .asJson();
 
     CaseContainerDTO caseContainerDTO = DataUtils.extractCaseIdDtoFromResponse(jsonResponse);
-    assertThat(caseContainerDTO.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(caseContainerDTO.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(caseContainerDTO.getAddressType()).isEqualTo(ADDRESS_TYPE_TEST);
   }
 
@@ -620,7 +620,7 @@ public class CaseEndpointIT {
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode())
         .isEqualTo("RM_TC");
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId())
-        .isEqualTo(caze.getCaseId().toString());
+        .isEqualTo(caze.getCaseId());
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId())
         .isNull();
 
@@ -630,7 +630,7 @@ public class CaseEndpointIT {
                 .getFulfilmentRequest()
                 .getUacQidCreated()
                 .getCaseId())
-        .isEqualTo(caze.getCaseId().toString());
+        .isEqualTo(caze.getCaseId());
     assertThat(
             responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getQid())
         .startsWith("01");
@@ -679,9 +679,9 @@ public class CaseEndpointIT {
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode())
         .isEqualTo("RM_TC_HI");
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId())
-        .isEqualTo(parentCase.getCaseId().toString());
+        .isEqualTo(parentCase.getCaseId());
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId())
-        .isEqualTo(individualCaseId.toString());
+        .isEqualTo(individualCaseId);
 
     assertThat(
             responseManagementEvent
@@ -689,7 +689,7 @@ public class CaseEndpointIT {
                 .getFulfilmentRequest()
                 .getUacQidCreated()
                 .getCaseId())
-        .isEqualTo(individualCaseId.toString());
+        .isEqualTo(individualCaseId);
     assertThat(
             responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getQid())
         .startsWith("21");
@@ -755,7 +755,7 @@ public class CaseEndpointIT {
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getFulfilmentCode())
         .isEqualTo("RM_TC");
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getCaseId())
-        .isEqualTo(caze.getCaseId().toString());
+        .isEqualTo(caze.getCaseId());
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getIndividualCaseId())
         .isNull();
 
@@ -765,7 +765,7 @@ public class CaseEndpointIT {
                 .getFulfilmentRequest()
                 .getUacQidCreated()
                 .getCaseId())
-        .isEqualTo(caze.getCaseId().toString());
+        .isEqualTo(caze.getCaseId());
     assertThat(
             responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated().getQid())
         .startsWith("21");
@@ -832,7 +832,7 @@ public class CaseEndpointIT {
             new TypeReference<List<CaseContainerDTO>>() {});
 
     assertThat(foundCases).hasSize(1);
-    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId().toString());
+    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId());
   }
 
   @Test
@@ -840,8 +840,8 @@ public class CaseEndpointIT {
 
     // Given
     Case[] matchCases = setupCcsCasesWithPostcode(TEST_POSTCODE_NO_SPACE, 3);
-    Set<String> expectedCaseIds =
-        Arrays.stream(matchCases).map(c -> c.getCaseId().toString()).collect(Collectors.toSet());
+    Set<UUID> expectedCaseIds =
+        Arrays.stream(matchCases).map(c -> c.getCaseId()).collect(Collectors.toSet());
 
     // When
     HttpResponse<JsonNode> jsonResponse =
@@ -859,7 +859,7 @@ public class CaseEndpointIT {
             new TypeReference<List<CaseContainerDTO>>() {});
 
     assertThat(foundCases).hasSize(3);
-    Set<String> actualCaseIds =
+    Set<UUID> actualCaseIds =
         foundCases.stream().map(CaseContainerDTO::getCaseId).collect(Collectors.toSet());
     assertThat(actualCaseIds).isEqualTo(expectedCaseIds);
   }
@@ -886,7 +886,7 @@ public class CaseEndpointIT {
             new TypeReference<List<CaseContainerDTO>>() {});
 
     assertThat(foundCases).hasSize(1);
-    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId().toString());
+    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId());
   }
 
   @Test
@@ -911,7 +911,7 @@ public class CaseEndpointIT {
             new TypeReference<List<CaseContainerDTO>>() {});
 
     assertThat(foundCases).hasSize(1);
-    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId().toString());
+    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId());
   }
 
   @Test
@@ -934,7 +934,7 @@ public class CaseEndpointIT {
             new TypeReference<List<CaseContainerDTO>>() {});
 
     assertThat(foundCases).hasSize(1);
-    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId().toString());
+    assertThat(foundCases.get(0).getCaseId()).isEqualTo(ccsCase.getCaseId());
   }
 
   @Test
@@ -952,7 +952,7 @@ public class CaseEndpointIT {
 
     CaseContainerDTO actualData = extractCaseContainerDTOFromResponse(response);
 
-    assertThat(actualData.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(actualData.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(actualData.getCaseEvents().size()).isEqualTo(0);
     assertThat(actualData.getSecureEstablishment()).isTrue();
   }
@@ -972,7 +972,7 @@ public class CaseEndpointIT {
 
     CaseContainerDTO actualData = extractCaseContainerDTOFromResponse(response);
 
-    assertThat(actualData.getCaseId()).isEqualTo(TEST_CASE_ID_1_EXISTS);
+    assertThat(actualData.getCaseId()).isEqualTo(UUID.fromString(TEST_CASE_ID_1_EXISTS));
     assertThat(actualData.getCaseEvents().size()).isEqualTo(0);
     assertThat(actualData.getSecureEstablishment()).isFalse();
   }
@@ -1136,7 +1136,7 @@ public class CaseEndpointIT {
     caseRepo.saveAndFlush(caze);
 
     return caseRepo
-        .findByCaseId(UUID.fromString(caze.getCaseId().toString()))
+        .findByCaseId(caze.getCaseId())
         .orElseThrow(() -> new RuntimeException("Case not found!"));
   }
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/UacQidServiceTest.java
@@ -34,7 +34,7 @@ public class UacQidServiceTest {
   @Test
   public void createAndLinkUacQid() {
     // Given
-    String caseId = UUID.randomUUID().toString();
+    UUID caseId = UUID.randomUUID();
     when(uacQidServiceClient.generateUacQid(eq(TEST_QUESTIONNAIRE_TYPE)))
         .thenReturn(createUacQidCreatedPayload(NEW_QID));
 
@@ -51,7 +51,7 @@ public class UacQidServiceTest {
   @Test
   public void createAndLinkUacQidReturnsALovelyObjectWhichIAmVeryFondOf() {
     // Given
-    String caseId = UUID.randomUUID().toString();
+    UUID caseId = UUID.randomUUID();
     UacQidCreatedPayloadDTO expectedResult = createUacQidCreatedPayload(NEW_QID);
     when(uacQidServiceClient.generateUacQid(eq(TEST_QUESTIONNAIRE_TYPE)))
         .thenReturn(expectedResult);

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -121,7 +121,7 @@ public class DataUtils {
     return uacQidCreatedPayloadDTO;
   }
 
-  public static UacQidCreatedPayloadDTO createUacQidCreatedPayload(String qid, String caseId) {
+  public static UacQidCreatedPayloadDTO createUacQidCreatedPayload(String qid, UUID caseId) {
     UacQidCreatedPayloadDTO uacQidCreatedPayloadDTO = createUacQidCreatedPayload(qid);
     uacQidCreatedPayloadDTO.setCaseId(caseId);
     return uacQidCreatedPayloadDTO;

--- a/src/test/java/uk/gov/ons/census/caseapisvc/validation/RequestValidatorTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/validation/RequestValidatorTest.java
@@ -11,7 +11,7 @@ public class RequestValidatorTest {
   @Test
   public void testAllTheValidGetNewQidByCaseIdRequests() {
     testValidGetNewQidByCaseIdCombination("HH", "U", false, null);
-    testValidGetNewQidByCaseIdCombination("HH", "U", true, "test_case_id");
+    testValidGetNewQidByCaseIdCombination("HH", "U", true, UUID.randomUUID());
 
     testValidGetNewQidByCaseIdCombination("CE", "E", false, null);
     testValidGetNewQidByCaseIdCombination("CE", "E", true, null);
@@ -28,20 +28,20 @@ public class RequestValidatorTest {
   @Test
   public void testAllTheInvalidGetNewQidByCaseIdRequests() {
     testInvalidGetNewQidByCaseIdCombination("HH", "U", true, null);
-    testInvalidGetNewQidByCaseIdCombination("HH", "U", false, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("CE", "E", false, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("CE", "E", true, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("HH", "U", false, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("CE", "E", false, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("CE", "E", true, UUID.randomUUID());
     testInvalidGetNewQidByCaseIdCombination("CE", "U", false, null);
-    testInvalidGetNewQidByCaseIdCombination("CE", "U", false, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("CE", "U", true, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("SPG", "E", false, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("SPG", "E", true, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("SPG", "U", false, "test_case_id");
-    testInvalidGetNewQidByCaseIdCombination("SPG", "U", true, "test_case_id");
+    testInvalidGetNewQidByCaseIdCombination("CE", "U", false, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("CE", "U", true, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("SPG", "E", false, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("SPG", "E", true, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("SPG", "U", false, UUID.randomUUID());
+    testInvalidGetNewQidByCaseIdCombination("SPG", "U", true, UUID.randomUUID());
   }
 
   private void testValidGetNewQidByCaseIdCombination(
-      String caseType, String addressLevel, boolean individual, String individualCaseId) {
+      String caseType, String addressLevel, boolean individual, UUID individualCaseId) {
     UUID caseId = UUID.randomUUID();
     Case caze = new Case();
     caze.setCaseId(caseId);
@@ -52,7 +52,7 @@ public class RequestValidatorTest {
   }
 
   private void testInvalidGetNewQidByCaseIdCombination(
-      String caseType, String addressLevel, boolean individual, String individualCaseId) {
+      String caseType, String addressLevel, boolean individual, UUID individualCaseId) {
     UUID caseId = UUID.randomUUID();
     Case caze = new Case();
     caze.setCaseId(caseId);


### PR DESCRIPTION
# Motivation and Context
Use UUID data type to hold UUID data

# What has changed
Updated entity.

# How to test?
- Build it and run it against the acceptance tests (master), with `use-UUID-type-for-UUId-data` branches of DDL, case-processor, action-scheduler, action-worker and action-processor.

# Links
- https://trello.com/c/r9qwqhaS