### PR TITLE
Use date type for dates

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/ResponseDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/ResponseDTO.java
@@ -1,9 +1,10 @@
 package uk.gov.ons.census.caseapisvc.model.dto;
 
+import java.time.OffsetDateTime;
 import lombok.Data;
 
 @Data
 class ResponseDTO {
-  private String dateTime;
+  private OffsetDateTime dateTime;
   private String inboundChannel;
 }


### PR DESCRIPTION
# Motivation and Context
We want to take advantage of Java's strong typing, and to use `OffsetDateTime` for date types, not strings.

# What has changed
Changed anywhere that was using a string for date/time/timestamp to use `OffsetDateTime`.

# How to test?
Run the ATs - should be zero regression.

# Links
Trello: https://trello.com/c/PbcNYiWe