### PR TITLE
1221 r ops search for case and show results

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpoint.java
@@ -152,6 +152,13 @@ public final class CaseEndpoint {
     return handleTelephoneCaptureRequest(caze, individual);
   }
 
+  @GetMapping(value = "/postcode/{postcode}")
+  public List<CaseContainerDTO> getCasesByPostcode(@PathVariable("postcode") String postcode) {
+    log.with("postcode", postcode).debug("Entering getCasesByPostcode");
+    List<Case> cases = caseService.findByPostcode(postcode);
+    return cases.stream().map(c -> buildCaseContainerDTO(c, false)).collect(Collectors.toList());
+  }
+
   private TelephoneCaptureDTO handleTelephoneCaptureRequest(Case caze, boolean individual) {
 
     int questionnaireType =

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -25,7 +25,8 @@ import org.hibernate.annotations.UpdateTimestamp;
     name = "cases",
     indexes = {
       @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
-      @Index(name = "lsoa_idx", columnList = "lsoa")
+      @Index(name = "lsoa_idx", columnList = "lsoa"),
+      @Index(name = "postcode_idx", columnList = "postcode")
     })
 public class Case {
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
@@ -18,6 +18,10 @@ public interface CaseRepository extends JpaRepository<Case, UUID> {
   Optional<Case> findByCaseRef(long reference);
 
   @Query(
+      "SELECT c FROM Case c WHERE UPPER(REPLACE(postcode, ' ', '')) = UPPER(REPLACE(:postcode, ' ', ''))")
+  List<Case> findByPostcode(String postcode);
+
+  @Query(
       "SELECT c FROM Case c WHERE survey='CCS' AND UPPER(REPLACE(postcode, ' ', '')) = UPPER(REPLACE(:postcode, ' ', ''))")
   List<Case> findCCSCasesByPostcodeIgnoringCaseAndSpaces(@Param("postcode") String postcode);
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/repository/CaseRepository.java
@@ -19,7 +19,7 @@ public interface CaseRepository extends JpaRepository<Case, UUID> {
 
   @Query(
       "SELECT c FROM Case c WHERE UPPER(REPLACE(postcode, ' ', '')) = UPPER(REPLACE(:postcode, ' ', ''))")
-  List<Case> findByPostcode(String postcode);
+  List<Case> findByPostcode(@Param("postcode") String postcode);
 
   @Query(
       "SELECT c FROM Case c WHERE survey='CCS' AND UPPER(REPLACE(postcode, ' ', '')) = UPPER(REPLACE(:postcode, ' ', ''))")

--- a/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/service/CaseService.java
@@ -99,6 +99,10 @@ public class CaseService {
         .orElseThrow(() -> new QidNotFoundException(caseId));
   }
 
+  public List<Case> findByPostcode(String postcode) {
+    return caseRepo.findByPostcode(postcode);
+  }
+
   public void buildAndSendTelephoneCaptureFulfilmentRequest(
       UUID caseId,
       String fulfilmentCode,

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -607,7 +607,8 @@ public class CaseEndpointUnitTest {
         .andExpect(handler().handlerType(CaseEndpoint.class))
         .andExpect(jsonPath("$").isArray())
         .andExpect(jsonPath("$", hasSize(1)))
-        .andExpect(jsonPath("$[0].id", is(caze.getCaseId().toString())));
+        .andExpect(jsonPath("$[0].id", is(caze.getCaseId().toString())))
+        .andExpect(jsonPath("$[0].postcode", is(caze.getPostcode())));
   }
 
   private String createUrl(String urlFormat, String param1) {

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointUnitTest.java
@@ -15,6 +15,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.CREATED_UAC;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.TEST_CCS_QID;
+import static uk.gov.ons.census.caseapisvc.utility.DataUtils.TEST_POSTCODE;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createCasesWithAddressInvalid;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createCcsUacQidLink;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createMultipleCasesWithEvents;
@@ -592,6 +593,21 @@ public class CaseEndpointUnitTest {
         .andExpect(jsonPath("$", hasSize(1)))
         .andExpect(jsonPath("$[0].id", is(ccsCase.getCaseId().toString())))
         .andExpect(jsonPath("$[0].postcode", is(ccsCase.getPostcode())));
+  }
+
+  @Test
+  public void getCasesByPostcode() throws Exception {
+    Case caze = createSingleCaseWithEvents();
+    when(caseService.findByPostcode(TEST_POSTCODE)).thenReturn(List.of((caze)));
+
+    mockMvc
+        .perform(
+            get(createUrl("/cases/postcode/%s", TEST_POSTCODE)).accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(handler().handlerType(CaseEndpoint.class))
+        .andExpect(jsonPath("$").isArray())
+        .andExpect(jsonPath("$", hasSize(1)))
+        .andExpect(jsonPath("$[0].id", is(caze.getCaseId().toString())));
   }
 
   private String createUrl(String urlFormat, String param1) {

--- a/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/service/CaseServiceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.TEST_CCS_QID;
+import static uk.gov.ons.census.caseapisvc.utility.DataUtils.TEST_POSTCODE;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createMultipleCasesWithEvents;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createSingleCaseWithEvents;
 import static uk.gov.ons.census.caseapisvc.utility.DataUtils.createSingleCcsCaseWithCcsQid;
@@ -199,5 +200,26 @@ public class CaseServiceTest {
         .isEqualTo("RM_TC_HI");
     assertThat(responseManagementEvent.getPayload().getFulfilmentRequest().getUacQidCreated())
         .isEqualTo(uacQidCreated);
+  }
+
+  @Test
+  public void testFindCasesByPostcode() {
+    // Given
+    Case expectedCase = createSingleCaseWithEvents();
+    expectedCase.setPostcode(TEST_POSTCODE);
+
+    when(caseRepo.findByPostcode(eq(TEST_POSTCODE))).thenReturn(List.of(expectedCase));
+
+    // When
+    List<Case> actualCases = caseService.findByPostcode(TEST_POSTCODE);
+
+    // Then
+    assertThat(actualCases).hasSize(1);
+    assertThat(actualCases.get(0)).isEqualTo(expectedCase);
+
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(caseRepo).findByPostcode(captor.capture());
+    String actualPostcode = captor.getValue();
+    assertThat(actualPostcode).isEqualTo(TEST_POSTCODE);
   }
 }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/utility/DataUtils.java
@@ -30,6 +30,7 @@ public class DataUtils {
 
   public static final String TEST_CCS_QID = "7130000000000000";
   public static final String CREATED_UAC = "created UAC";
+  public static final String TEST_POSTCODE = "AB1 2BC";
 
   public static final ObjectMapper mapper;
 
@@ -85,6 +86,7 @@ public class DataUtils {
     caze.setUacQidLinks(uacQidLinks);
     caze.setSurvey("CENSUS");
     caze.setMetadata(new CaseMetadata());
+    caze.setPostcode(TEST_POSTCODE);
 
     return caze;
   }

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -39,6 +39,8 @@ services:
       - QUEUECONFIG_UAC_QID_CREATED_QUEUE=dummy.uac-qid-created
       - JAVA_OPTS=-Xmx128m -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5121 -Dspring.profiles.active=dev
       - CASEREFGENERATORKEY=6+VLkvz5XYkF7vFLVX7FDnfxavQ7M+iY
+      - SPRING_CLOUD_GCP_PUBSUB_EMULATOR_HOST=localhost:18538
+      - SPRING_CLOUD_GCP_PUBSUB_PROJECT_ID=aims-new-address-project
     healthcheck:
       test: ["CMD", "cat", "/tmp/case-service-healthy"]
       interval: 30s


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The first feature needed for ops-ui is to be able to search for cases via a postcode. This PR adds the postcode API call needed to get cases via postcode

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added new endpoint for getting cases via postcode

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run mvn clean install
- Run with the other branches on the ticket and run the ATs

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/qkkjvupd)
