### PR TITLE
Remove postode index

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -26,7 +26,6 @@ import org.hibernate.annotations.UpdateTimestamp;
     indexes = {
       @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
       @Index(name = "lsoa_idx", columnList = "lsoa"),
-      @Index(name = "postcode_idx", columnList = "postcode")
     })
 public class Case {
 


### PR DESCRIPTION
# Motivation and Context
See https://github.com/ONSdigital/census-rm-case-processor/pull/200, mirroring those changes.

# Links
https://github.com/ONSdigital/census-rm-case-processor/pull/200
https://trello.com/c/fg58euQh/1361-add-a-fancy-pants-index-on-postcode-column-to-speed-up-rops-query-time