### PR TITLE
AddressTypeChange for CE Case ceActualResponses Defaulted to Zero

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseDetailsDTO.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/dto/CaseDetailsDTO.java
@@ -69,7 +69,7 @@ public class CaseDetailsDTO {
 
   private Integer ceExpectedCapacity;
 
-  private Integer ceActualResponses;
+  private int ceActualResponses;
 
   private UUID collectionExerciseId;
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -99,7 +99,7 @@ public class Case {
 
   @Column private Integer ceExpectedCapacity;
 
-  @Column private Integer ceActualResponses;
+  @Column private int ceActualResponses;
 
   @Column private UUID collectionExerciseId;
 

--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -99,7 +99,8 @@ public class Case {
 
   @Column private Integer ceExpectedCapacity;
 
-  @Column private int ceActualResponses;
+  @Column(nullable = false)
+  private int ceActualResponses;
 
   @Column private UUID collectionExerciseId;
 

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -1059,9 +1059,11 @@ public class CaseEndpointIT {
     assertThat(response.getStatus()).isEqualTo(OK.value());
 
     CaseDetailsDTO actualCaseDetails = extractCaseDetailsDTOsFromResponse(response);
+    actualCaseDetails.setCeActualResponses(0);
 
     assertThat(actualCaseDetails.getCaseId()).isEqualTo(caze.getCaseId());
     assertThat(actualCaseDetails.getEvents().size()).isEqualTo(1);
+    assertThat(actualCaseDetails.getCeActualResponses()).isEqualTo(0);
     assertThat(actualCaseDetails.getEvents().get(0).getEventType())
         .isEqualTo(EventType.CASE_CREATED.toString());
   }

--- a/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
+++ b/src/test/java/uk/gov/ons/census/caseapisvc/endpoint/CaseEndpointIT.java
@@ -1059,11 +1059,9 @@ public class CaseEndpointIT {
     assertThat(response.getStatus()).isEqualTo(OK.value());
 
     CaseDetailsDTO actualCaseDetails = extractCaseDetailsDTOsFromResponse(response);
-    actualCaseDetails.setCeActualResponses(0);
 
     assertThat(actualCaseDetails.getCaseId()).isEqualTo(caze.getCaseId());
     assertThat(actualCaseDetails.getEvents().size()).isEqualTo(1);
-    assertThat(actualCaseDetails.getCeActualResponses()).isEqualTo(0);
     assertThat(actualCaseDetails.getEvents().get(0).getEventType())
         .isEqualTo(EventType.CASE_CREATED.toString());
   }


### PR DESCRIPTION
# Motivation and Context
When an AddressTypeChange event occurs where the new address is a CE Case, the ceActualResponses is null rather than 0 

# What has changed
Changed ceActualResponses from Integer to int so now defaults to 0 instead of null

# How to test?
Maven clean install on branch and check image builds and tests pass

# Links
https://trello.com/c/DUgevj8y