### PR TITLE
Add hostname to micrometer stackdriver metrics

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,7 @@ management:
   metrics:
     tags:
       application: Case API
+      pod: ${HOSTNAME}
     export:
       stackdriver:
         project-id: dummy-project-id

--- a/src/test/resources/definitions.json
+++ b/src/test/resources/definitions.json
@@ -193,6 +193,13 @@
       "durable": true,
       "auto_delete": false,
       "arguments": {}
+    },
+    {
+      "name": "case.rm.nonCompliance",
+      "vhost": "/",
+      "durable": true,
+      "auto_delete": false,
+      "arguments": {}
     }
   ],
   "exchanges": [


### PR DESCRIPTION
# Motivation and Context
If we run more than 1 Case API, StackDriver hates it because the instances are trying to overwrite each others' stats.

# What has changed
Added hostname (pod name) to stackdriver metatdata tags.

# How to test?
Do you really want to? Deploy it, run a bunch of Case APIs and then call Case API a bunch of times, and then explore the metrics in StackDriver I guess... tricky though.

# Links
Trello: https://trello.com/c/B6ukMZ27