### PR TITLE
1874 Add index to UPRN in case entity

### DIFF
--- a/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
+++ b/src/main/java/uk/gov/ons/census/caseapisvc/model/entity/Case.java
@@ -33,6 +33,7 @@ import org.hibernate.annotations.UpdateTimestamp;
     indexes = {
       @Index(name = "cases_case_ref_idx", columnList = "case_ref"),
       @Index(name = "lsoa_idx", columnList = "lsoa"),
+      @Index(name = "uprn_idx", columnList = "uprn"),
     })
 public class Case {
 


### PR DESCRIPTION
# Motivation and Context
We need speedy look ups on UPRN for case API, this PR adds an index to facilitate.

# What has changed
* Add index to UPRN in case entity

# How to test?
No functional changes. UPRN look up speed should be improved once this is deployed.
Should match the change in case processor.

# Links
https://trello.com/c/XWfypxu8/1874-add-indexes-to-uprn-field-in-cases-db-table-5
https://github.com/ONSdigital/census-rm-case-processor/pull/227
https://github.com/ONSdigital/census-rm-ddl/pull/84